### PR TITLE
ENH: Update X-Axis from QDateTimeEdits

### DIFF
--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -32,9 +32,6 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin):
         plot_viewbox = self.ui.archiver_plot.plotItem.vb
         plot_viewbox.sigRangeChangedManually.connect(self.ui.cursor_scale_btn.click)
 
-        plot_x_axis = self.ui.archiver_plot.getXAxis()
-        plot_x_axis.sigMouseInteraction.connect(self.ui.cursor_scale_btn.click)
-
         app = QApplication.instance()
         app.setStyle(CenterCheckStyle())
 

--- a/archive_viewer/archive_viewer.ui
+++ b/archive_viewer/archive_viewer.ui
@@ -235,8 +235,11 @@
           </item>
           <item>
            <widget class="QDateTimeEdit" name="main_start_datetime">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
             <property name="displayFormat">
-             <string>MM/dd/yyyy hh:mm:ss.zzz</string>
+             <string>MM/dd/yyyy hh:mm:ss</string>
             </property>
             <property name="calendarPopup">
              <bool>true</bool>
@@ -245,8 +248,11 @@
           </item>
           <item>
            <widget class="QDateTimeEdit" name="main_end_datetime">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
             <property name="displayFormat">
-             <string>MM/dd/yyyy hh:mm:ss.zzz </string>
+             <string>MM/dd/yyyy hh:mm:ss</string>
             </property>
             <property name="calendarPopup">
              <bool>true</bool>

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -1,5 +1,8 @@
-from qtpy.QtCore import Slot
+from typing import Tuple
+from datetime import datetime
+from qtpy.QtCore import Slot, QDateTime
 from qtpy.QtWidgets import QHeaderView
+from pyqtgraph import ViewBox
 from table_models import ArchiverAxisModel
 from widgets import ComboBoxDelegate, ScientificNotationDelegate
 
@@ -19,6 +22,13 @@ class AxisTableMixin:
         self.ui.add_axis_row_btn.clicked.connect(self.addAxis)
         self.ui.del_axis_row_btn.clicked.connect(self.removeSelectedAxis)
 
+        plot_viewbox = self.ui.archiver_plot.plotItem.vb
+        plot_viewbox.sigXRangeChanged.connect(self.set_axis_datetimes)
+        plot_viewbox.sigRangeChangedManually.connect(lambda *_: self.set_axis_datetimes())
+
+        self.ui.main_start_datetime.dateTimeChanged.connect(lambda qdt: self.set_time_axis_range((qdt, None)))
+        self.ui.main_end_datetime.dateTimeChanged.connect(lambda qdt: self.set_time_axis_range((None, qdt)))
+
     def axis_delegates_init(self) -> None:
         """Initialize and set the ItemDelegates for the axis table."""
         orientation_col = self.axis_table_model.getColumnIndex("Y-Axis Orientation")
@@ -33,6 +43,57 @@ class AxisTableMixin:
         max_range_col = self.axis_table_model.getColumnIndex("Max Y Range")
         max_range_del = ScientificNotationDelegate(self.ui.time_axis_tbl)
         self.ui.time_axis_tbl.setItemDelegateForColumn(max_range_col, max_range_del)
+
+    Slot(object)
+    def set_time_axis_range(self, raw_range: Tuple[QDateTime, QDateTime] = (None, None)) -> None:
+        """PyQT Slot to set the plot's X-Axis range. This slot should be
+        triggered on QDateTimeEdit value change.
+
+        Parameters
+        ----------
+        raw_range : Tuple[QDateTime], optional
+            Takes in a tuple of 2 values, where one is a QDateTime and
+            the other is None. The positioning changes either the plot's
+            min or max range value. By default (None, None)
+        """
+        proc_range = [None, None]
+        for ind, val in enumerate(raw_range):
+            # Values that are QDateTime are converted to a float timestamp
+            if isinstance(val, QDateTime):
+                proc_range[ind] = val.toSecsSinceEpoch()
+            # Values that are None use the existing range value
+            elif not val:
+                proc_range[ind] = self.ui.archiver_plot.getXAxis().range[ind]
+        proc_range.sort()
+
+        self.ui.archiver_plot.plotItem.vb.blockSignals(True)
+        self.ui.archiver_plot.plotItem.setXRange(*raw_range)
+        self.ui.archiver_plot.plotItem.vb.blockSignals(False)
+
+    @Slot(object, object)
+    def set_axis_datetimes(self, _: ViewBox = None, time_range: Tuple[float, float] = None) -> None:
+        """Slot used to update the QDateTimeEdits on the Axis tab. This
+        slot is called when the plot's X-Axis range changes values.
+
+        Parameters
+        ----------
+        _ : ViewBox, optional
+            The ViewBox on which the range is changing. This is unused
+        time_range : Tuple[float, float], optional
+            The new range values for the QDateTimeEdits, by default None
+        """
+        if not time_range:
+            time_range = self.ui.archiver_plot.getXAxis().range
+        if min(time_range) <= 0:
+            return
+
+        time_range = [datetime.fromtimestamp(f) for f in time_range]
+
+        edits = (self.ui.main_start_datetime, self.ui.main_end_datetime)
+        for ind, qdt in enumerate(edits):
+            qdt.blockSignals(True)
+            qdt.setDateTime(QDateTime(time_range[ind]))
+            qdt.blockSignals(False)
 
     @Slot()
     def addAxis(self) -> None:

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -56,6 +56,9 @@ class AxisTableMixin:
             the other is None. The positioning changes either the plot's
             min or max range value. By default (None, None)
         """
+        # Disable Autoscroll if enabled
+        self.ui.cursor_scale_btn.click()
+
         proc_range = [None, None]
         for ind, val in enumerate(raw_range):
             # Values that are QDateTime are converted to a float timestamp
@@ -69,8 +72,6 @@ class AxisTableMixin:
         self.ui.archiver_plot.plotItem.vb.blockSignals(True)
         self.ui.archiver_plot.plotItem.setXRange(*proc_range)
         self.ui.archiver_plot.plotItem.vb.blockSignals(False)
-
-        self.ui.cursor_scale_btn.click()
 
     @Slot(object, object)
     def set_axis_datetimes(self, _: ViewBox = None, time_range: Tuple[float, float] = None) -> None:

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -67,8 +67,10 @@ class AxisTableMixin:
         proc_range.sort()
 
         self.ui.archiver_plot.plotItem.vb.blockSignals(True)
-        self.ui.archiver_plot.plotItem.setXRange(*raw_range)
+        self.ui.archiver_plot.plotItem.setXRange(*proc_range)
         self.ui.archiver_plot.plotItem.vb.blockSignals(False)
+
+        self.ui.cursor_scale_btn.click()
 
     @Slot(object, object)
     def set_axis_datetimes(self, _: ViewBox = None, time_range: Tuple[float, float] = None) -> None:
@@ -91,6 +93,8 @@ class AxisTableMixin:
 
         edits = (self.ui.main_start_datetime, self.ui.main_end_datetime)
         for ind, qdt in enumerate(edits):
+            if qdt.hasFocus():
+                continue
             qdt.blockSignals(True)
             qdt.setDateTime(QDateTime(time_range[ind]))
             qdt.blockSignals(False)


### PR DESCRIPTION
This PR gives functionality to the QDateTimeEdits in the Axes tab of the Archive Viewer:

The values in the QDateTimeEdits will be updated to reflect changes to the plot's X-Axis. Changing the values in these widgets also makes the expected change to the plot's X-Axis.

Caveats:
- If the user is editing a QDateTimeEdit's value, then it will not reflect changes to the X-Axis. This would be disruptive and prevent the user from setting the desired range value.
- If the left timestamp is larger than the right timestamp, then the smaller value is set as the X-Axis range "minimum", regardless of being set in the "maximum" QDateTimeEdit. And vice versa.