### PR TITLE
ENH: Replace Delete Axis button with inline button

### DIFF
--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -32,9 +32,6 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin):
         plot_viewbox = self.ui.archiver_plot.plotItem.vb
         plot_viewbox.sigRangeChangedManually.connect(self.ui.cursor_scale_btn.click)
 
-        plot_x_axis = self.ui.archiver_plot.getXAxis()
-        plot_x_axis.sigMouseInteraction.connect(self.ui.cursor_scale_btn.click)
-
         app = QApplication.instance()
         app.setStyle(CenterCheckStyle())
 

--- a/archive_viewer/archive_viewer.ui
+++ b/archive_viewer/archive_viewer.ui
@@ -293,13 +293,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QPushButton" name="del_axis_row_btn">
-            <property name="text">
-             <string>Delete Axis</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
        </layout>

--- a/archive_viewer/archive_viewer.ui
+++ b/archive_viewer/archive_viewer.ui
@@ -235,8 +235,11 @@
           </item>
           <item>
            <widget class="QDateTimeEdit" name="main_start_datetime">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
             <property name="displayFormat">
-             <string>MM/dd/yyyy hh:mm:ss.zzz</string>
+             <string>MM/dd/yyyy hh:mm:ss</string>
             </property>
             <property name="calendarPopup">
              <bool>true</bool>
@@ -245,8 +248,11 @@
           </item>
           <item>
            <widget class="QDateTimeEdit" name="main_end_datetime">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
             <property name="displayFormat">
-             <string>MM/dd/yyyy hh:mm:ss.zzz </string>
+             <string>MM/dd/yyyy hh:mm:ss</string>
             </property>
             <property name="calendarPopup">
              <bool>true</bool>

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -4,7 +4,7 @@ from qtpy.QtCore import Slot, QDateTime
 from qtpy.QtWidgets import QHeaderView
 from pyqtgraph import ViewBox
 from table_models import ArchiverAxisModel
-from widgets import ComboBoxDelegate, ScientificNotationDelegate
+from widgets import ComboBoxDelegate, ScientificNotationDelegate, DeleteRowDelegate
 
 
 class AxisTableMixin:
@@ -18,9 +18,8 @@ class AxisTableMixin:
 
         hdr = self.ui.time_axis_tbl.horizontalHeader()
         hdr.setSectionResizeMode(QHeaderView.Stretch)
-
-        self.ui.add_axis_row_btn.clicked.connect(self.addAxis)
-        self.ui.del_axis_row_btn.clicked.connect(self.removeSelectedAxis)
+        del_col = self.axis_table_model.getColumnIndex("")
+        hdr.setSectionResizeMode(del_col, QHeaderView.ResizeToContents)
 
         plot_viewbox = self.ui.archiver_plot.plotItem.vb
         plot_viewbox.sigXRangeChanged.connect(self.set_axis_datetimes)
@@ -28,6 +27,8 @@ class AxisTableMixin:
 
         self.ui.main_start_datetime.dateTimeChanged.connect(lambda qdt: self.set_time_axis_range((qdt, None)))
         self.ui.main_end_datetime.dateTimeChanged.connect(lambda qdt: self.set_time_axis_range((None, qdt)))
+
+        self.ui.add_axis_row_btn.clicked.connect(self.addAxis)
 
     def axis_delegates_init(self) -> None:
         """Initialize and set the ItemDelegates for the axis table."""
@@ -43,6 +44,10 @@ class AxisTableMixin:
         max_range_col = self.axis_table_model.getColumnIndex("Max Y Range")
         max_range_del = ScientificNotationDelegate(self.ui.time_axis_tbl)
         self.ui.time_axis_tbl.setItemDelegateForColumn(max_range_col, max_range_del)
+
+        delete_col = self.axis_table_model.getColumnIndex("")
+        delete_row_del = DeleteRowDelegate(self.ui.time_axis_tbl)
+        self.ui.time_axis_tbl.setItemDelegateForColumn(delete_col, delete_row_del)
 
     Slot(object)
     def set_time_axis_range(self, raw_range: Tuple[QDateTime, QDateTime] = (None, None)) -> None:
@@ -103,8 +108,3 @@ class AxisTableMixin:
     def addAxis(self) -> None:
         """Slot for button to add a new row to the axis table."""
         self.axis_table_model.append()
-
-    @Slot()
-    def removeSelectedAxis(self) -> None:
-        """Slot for button to remove a row from the axis table."""
-        self.axis_table_model.removeAtIndex(self.ui.time_axis_tbl.currentIndex())

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -1,5 +1,8 @@
-from qtpy.QtCore import Slot
+from typing import Tuple
+from datetime import datetime
+from qtpy.QtCore import Slot, QDateTime
 from qtpy.QtWidgets import QHeaderView
+from pyqtgraph import ViewBox
 from table_models import ArchiverAxisModel
 from widgets import ComboBoxDelegate, ScientificNotationDelegate
 
@@ -19,6 +22,13 @@ class AxisTableMixin:
         self.ui.add_axis_row_btn.clicked.connect(self.addAxis)
         self.ui.del_axis_row_btn.clicked.connect(self.removeSelectedAxis)
 
+        plot_viewbox = self.ui.archiver_plot.plotItem.vb
+        plot_viewbox.sigXRangeChanged.connect(self.set_axis_datetimes)
+        plot_viewbox.sigRangeChangedManually.connect(lambda *_: self.set_axis_datetimes())
+
+        self.ui.main_start_datetime.dateTimeChanged.connect(lambda qdt: self.set_time_axis_range((qdt, None)))
+        self.ui.main_end_datetime.dateTimeChanged.connect(lambda qdt: self.set_time_axis_range((None, qdt)))
+
     def axis_delegates_init(self) -> None:
         """Initialize and set the ItemDelegates for the axis table."""
         orientation_col = self.axis_table_model.getColumnIndex("Y-Axis Orientation")
@@ -33,6 +43,57 @@ class AxisTableMixin:
         max_range_col = self.axis_table_model.getColumnIndex("Max Y Range")
         max_range_del = ScientificNotationDelegate(self.ui.time_axis_tbl)
         self.ui.time_axis_tbl.setItemDelegateForColumn(max_range_col, max_range_del)
+
+    Slot(object)
+    def set_time_axis_range(self, raw_range: Tuple[QDateTime, QDateTime] = (None, None)) -> None:
+        """PyQT Slot to set the plot's X-Axis range. This slot should be
+        triggered on QDateTimeEdit value change.
+
+        Parameters
+        ----------
+        raw_range : Tuple[QDateTime], optional
+            Takes in a tuple of 2 values, where one is a QDateTime and
+            the other is None. The positioning changes either the plot's
+            min or max range value. By default (None, None)
+        """
+        proc_range = [None, None]
+        for ind, val in enumerate(raw_range):
+            # Values that are QDateTime are converted to a float timestamp
+            if isinstance(val, QDateTime):
+                proc_range[ind] = val.toSecsSinceEpoch()
+            # Values that are None use the existing range value
+            elif not val:
+                proc_range[ind] = self.ui.archiver_plot.getXAxis().range[ind]
+        proc_range.sort()
+
+        self.ui.archiver_plot.plotItem.vb.blockSignals(True)
+        self.ui.archiver_plot.plotItem.setXRange(*raw_range)
+        self.ui.archiver_plot.plotItem.vb.blockSignals(False)
+
+    @Slot(object, object)
+    def set_axis_datetimes(self, _: ViewBox = None, time_range: Tuple[float, float] = None) -> None:
+        """Slot used to update the QDateTimeEdits on the Axis tab. This
+        slot is called when the plot's X-Axis range changes values.
+
+        Parameters
+        ----------
+        _ : ViewBox, optional
+            The ViewBox on which the range is changing. This is unused
+        time_range : Tuple[float, float], optional
+            The new range values for the QDateTimeEdits, by default None
+        """
+        if not time_range:
+            time_range = self.ui.archiver_plot.getXAxis().range
+        if min(time_range) <= 0:
+            return
+
+        time_range = [datetime.fromtimestamp(f) for f in time_range]
+
+        edits = (self.ui.main_start_datetime, self.ui.main_end_datetime)
+        for ind, qdt in enumerate(edits):
+            qdt.blockSignals(True)
+            qdt.setDateTime(QDateTime(time_range[ind]))
+            qdt.blockSignals(False)
 
     @Slot()
     def addAxis(self) -> None:

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -67,8 +67,10 @@ class AxisTableMixin:
         proc_range.sort()
 
         self.ui.archiver_plot.plotItem.vb.blockSignals(True)
-        self.ui.archiver_plot.plotItem.setXRange(*raw_range)
+        self.ui.archiver_plot.plotItem.setXRange(*proc_range)
         self.ui.archiver_plot.plotItem.vb.blockSignals(False)
+
+        self.ui.cursor_scale_btn.click()
 
     @Slot(object, object)
     def set_axis_datetimes(self, _: ViewBox = None, time_range: Tuple[float, float] = None) -> None:
@@ -91,6 +93,8 @@ class AxisTableMixin:
 
         edits = (self.ui.main_start_datetime, self.ui.main_end_datetime)
         for ind, qdt in enumerate(edits):
+            if qdt.hasFocus():
+                continue
             qdt.blockSignals(True)
             qdt.setDateTime(QDateTime(time_range[ind]))
             qdt.blockSignals(False)

--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -27,7 +27,8 @@ class TracesTableMixin:
         hdr.setSectionResizeMode(QHeaderView.Stretch)
         channel_col = self.curves_model.getColumnIndex("Channel")
         hdr.setSectionResizeMode(channel_col, QHeaderView.ResizeToContents)
-        hdr.setSectionResizeMode(self.curves_model.getColumnIndex(""), QHeaderView.ResizeToContents)
+        del_col = self.curves_model.getColumnIndex("")
+        hdr.setSectionResizeMode(del_col, QHeaderView.ResizeToContents)
 
     def curve_delegates_init(self) -> None:
         """Set column delegates for the Traces table to display widgets."""

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -17,6 +17,8 @@ class ArchiverAxisModel(BasePlotAxesModel):
     """
     def __init__(self, plot: BasePlot, parent=None) -> None:
         super().__init__(plot, parent)
+        self._column_names = self._column_names + ("",)
+
         self.checkable_col = {self.getColumnIndex("Enable Auto Range"),
                               self.getColumnIndex("Log Mode")}
 
@@ -90,6 +92,18 @@ class ArchiverAxisModel(BasePlotAxesModel):
         new_axis = self.get_axis(-1)
         row = self.rowCount() - 1
         self.attach_range_changed(row, new_axis)
+
+    def removeAtIndex(self, index: QModelIndex) -> None:
+        """Removes the axis at the given table index.
+
+        Parameters
+        ----------
+        index : QModelIndex
+            An index in the row to be removed.
+        """
+        if self.rowCount() <= 1:
+            self.append()
+        super().removeAtIndex(index)
 
     def get_axis(self, index: int) -> BasePlotAxisItem:
         """Return the BasePlotAxisItem for a given row number.

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -278,7 +278,7 @@ class DeleteRowDelegate(QStyledItemDelegate):
             editor = QPushButton(self.parent())
             icon = editor.style().standardIcon(QStyle.SP_DialogCancelButton)
             editor.setIcon(icon)
-            editor.setToolTip("Delete Trace")
+            editor.setToolTip("Delete Row")
             editor.clicked.connect(lambda: self.commitData.emit(editor))
 
             self.editor_list.append(editor)


### PR DESCRIPTION
Includes changes from #17 

- Remove the Delete Axis button from the Axes tab:
  - This includes removing the associated slot from the AxisTableMixin
- Add an inline "row delete" button to each row:
  - This inline button is the same as the inline row deletion button in the Traces tab, meaning that they look and behave the same way
- Change to DeleteRowDelegate: 
  - Tooltip changed from "Delete Trace" to "Delete Row" to make it more general
- Change to ArchiverAxisModel.removeAtIndex:
  - If there is only one axis remaining, then deleting it would cause the plot to break
  - Instead, the model adds a new axis and removes the other one. This has the affect of resetting the only row and not breaking the plot
  - This captures an edge case