### PR TITLE
Archive Viewer file import and export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Config & Save files
+*.txt
+*.xml
+*.pyav
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -36,6 +36,11 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         app = QApplication.instance()
         app.setStyle(CenterCheckStyle())
 
+    def file_menu_items(self):
+        """Add export & import functionality to File menu"""
+        return {"save": (self.export_save_file, "Ctrl+S"),
+                "load": (self.import_save_file, "Ctrl+L")}
+
     @Slot(QAbstractButton)
     def set_plot_timerange(self, button: QAbstractButton) -> None:
         """Slot to be called when a timespan setting button is pressed.

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -36,8 +36,8 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         app = QApplication.instance()
         app.setStyle(CenterCheckStyle())
 
-    def file_menu_items(self):
-        """Add export & import functionality to File menu"""
+    def file_menu_items(self) -> dict:
+        """Add export & import functionality to File menu; override Display.file_menu_items"""
         return {"save": (self.export_save_file, "Ctrl+S"),
                 "load": (self.import_save_file, "Ctrl+L")}
 

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -1,13 +1,13 @@
 from functools import partial
 from qtpy.QtCore import Slot
-from qtpy.QtWidgets import QAbstractButton, QApplication
+from qtpy.QtWidgets import (QAbstractButton, QApplication)
 from pydm import Display
 from config import logger
-from mixins import (TracesTableMixin, AxisTableMixin)
+from mixins import (TracesTableMixin, AxisTableMixin, FileIOMixin)
 from styles import CenterCheckStyle
 
 
-class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin):
+class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
     def __init__(self, parent=None, args=None, macros=None, ui_filename=__file__.replace(".py", ".ui")) -> None:
         super(ArchiveViewer, self).__init__(parent=parent, args=args,
                                             macros=macros, ui_filename=ui_filename)
@@ -17,6 +17,7 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin):
 
         self.axis_table_init()
         self.traces_table_init()
+        self.file_io_init()
 
         self.curve_delegates_init()
         self.axis_delegates_init()

--- a/archive_viewer/archive_viewer.ui
+++ b/archive_viewer/archive_viewer.ui
@@ -25,6 +25,20 @@
    <item>
     <layout class="QHBoxLayout" name="scale_ctrl_lyt">
      <item>
+      <widget class="QPushButton" name="test_export_btn">
+       <property name="text">
+        <string>Test Export</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="test_import_btn">
+       <property name="text">
+        <string>Test Import</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="scale_ctrl_spcr">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -71,6 +85,9 @@
        <property name="checkable">
         <bool>true</bool>
        </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
        <attribute name="buttonGroup">
         <string notr="true">timespan_btns</string>
        </attribute>
@@ -111,7 +128,7 @@
         <bool>true</bool>
        </property>
        <property name="checked">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <attribute name="buttonGroup">
         <string notr="true">timespan_btns</string>

--- a/archive_viewer/archive_viewer.ui
+++ b/archive_viewer/archive_viewer.ui
@@ -25,20 +25,6 @@
    <item>
     <layout class="QHBoxLayout" name="scale_ctrl_lyt">
      <item>
-      <widget class="QPushButton" name="test_export_btn">
-       <property name="text">
-        <string>Test Export</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="test_import_btn">
-       <property name="text">
-        <string>Test Import</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="scale_ctrl_spcr">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/archive_viewer/av_file_convert.py
+++ b/archive_viewer/av_file_convert.py
@@ -25,6 +25,10 @@ else:
 
 
 class ArchiveViewerFileConverter():
+    """Converter class that will convert save files for the Java-based Archive
+    Viewer into a format readable by the Trace application. This class can also
+    be used for importing data into Trace or exporting data from it.
+    """
     # Java date time conversion regex
     full_java_absolute_re = compile(r"^[01]\d/[0-3]\d/\d{4}\s*((?:[01]\d|2[0-3])(?::[0-5]\d)(?::[0-5]\d(?:.\d*)?)?)?$")
     java_date_re = compile(r"^[01]\d/[0-3]\d/\d{4}")
@@ -193,6 +197,16 @@ class ArchiveViewerFileConverter():
     def reformat_date(cls, input_str: str) -> str:
         """Convert a time string from the format 'MM/DD/YYYY' --> 'YYYY-MM-DD'
         and retain time if included
+
+        Parameters
+        ----------
+        input_str : str
+            Date string in the format of 'MM/DD/YYYY'; can include a time
+
+        Returns
+        -------
+        str
+            Date string in the format of 'YYYY-MM-DD'
         """
         if not cls.full_java_absolute_re.fullmatch(input_str):
             return input_str
@@ -242,8 +256,19 @@ class ArchiveViewerFileConverter():
         return data_dict
 
     @staticmethod
-    def get_plot_data(plot: PyDMTimePlot) -> Dict:
-        """Extract plot, axis, and curve data from a PyDMTimePlot object"""
+    def get_plot_data(plot: PyDMTimePlot) -> dict:
+        """Extract plot, axis, and curve data from a PyDMTimePlot object
+
+        Parameters
+        ----------
+        plot : PyDMTimePlot
+            The PyDM Plotting object to extract data from. Gets plot, axis, and curve data.
+
+        Returns
+        -------
+        dict
+            A dictionary representation of all of the relevant data for the given plot
+        """
         output_dict = {'archiver_url': getenv("PYDM_ARCHIVER_URL"),
                        'plot': {},
                        'time_axis': {},
@@ -294,8 +319,19 @@ class ArchiveViewerFileConverter():
         return QColor(srgb)
 
     @staticmethod
-    def remove_null_values(dict_in: Dict) -> Dict:
-        """Remove all key-value pairs from a given dictionary where the value is None"""
+    def remove_null_values(dict_in: dict) -> dict:
+        """Remove all key-value pairs from a given dictionary where the value is None
+
+        Parameters
+        ----------
+        dict_in : dict
+            Some dictionary, possibly containing key-value pairs where value is None
+
+        Returns
+        -------
+        dict
+            The same dictionary, but with those key-value pairs deleted
+        """
         dict_out = dict_in.copy()
         for k, v in dict_in.items():
             if v is None:
@@ -339,15 +375,16 @@ def main(input_file: Path = None, output_file: Path = None, overwrite: bool = Fa
     return 0
 
 
-if __name__ == "__main__":
-    class PathAction(Action):
-        def __call__(self, parser: ArgumentParser, namespace: Namespace, values: str, option_string: str = None) -> None:
-            """Convert filepath string from argument into  a pathlib.Path object"""
-            new_path = path.expandvars(values)
-            new_path = Path(new_path).expanduser()
-            new_path = new_path.resolve()
-            setattr(namespace, self.dest, new_path)
+class PathAction(Action):
+    def __call__(self, parser: ArgumentParser, namespace: Namespace, values: str, option_string: str = None) -> None:
+        """Convert filepath string from argument into  a pathlib.Path object"""
+        new_path = path.expandvars(values)
+        new_path = Path(new_path).expanduser()
+        new_path = new_path.resolve()
+        setattr(namespace, self.dest, new_path)
 
+
+if __name__ == "__main__":
     parser = ArgumentParser(prog="Archive Viewer File Converter",
                             description="Convert files used by the Java Archive"
                             " Viewer to a file format that can be used with the"

--- a/archive_viewer/av_file_convert.py
+++ b/archive_viewer/av_file_convert.py
@@ -1,0 +1,345 @@
+import json
+import logging
+import xml.etree.ElementTree as ET
+from os import (path, getenv)
+from typing import (Dict, Union)
+from pathlib import Path
+from datetime import datetime
+from argparse import (ArgumentParser, Action, Namespace)
+from qtpy.QtGui import QColor
+from collections import OrderedDict
+from pydm.widgets.timeplot import PyDMTimePlot
+
+
+if __name__ in logging.Logger.manager.loggerDict:
+    logger = logging.getLogger(__name__)
+else:
+    logger = logging.getLogger("")
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)-8s] - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel("INFO")
+    handler.setLevel("INFO")
+
+
+class ArchiveViewerFileConverter():
+    def __init__(self, input_file: Union[str, Path] = "", output_file: Union[str, Path] = "") -> None:
+        self.input_file = input_file
+        self.output_file = output_file
+
+        self.stored_data = None
+
+    def import_is_xml(self):
+        """Helper function to determine if the import file is in XML format."""
+        with self.input_file.open() as f:
+            return f.readline().startswith("<?xml")
+
+    def import_file(self, file_name: Union[str, Path] = None) -> Dict:
+        """Import Archive Viewer save data from the provided file. The file
+        should be one of two types: '.pyav' or '.xml'. The data is returned as
+        well as saved in the stored_data property.
+
+        Parameters
+        ----------
+        file_name : str or pathlib.Path
+            The absolute filepath for the input file to import
+
+        Returns
+        -------
+        dict
+            A python dictionaty containing the data imported from the provided file
+        """
+        if file_name:
+            self.input_file = Path(file_name)
+        if not self.input_file.is_file():
+            raise FileNotFoundError(f"Data file not found: {self.input_file}")
+
+        with self.input_file.open() as f:
+            is_xml = f.readline().startswith("<?xml")
+
+        text = self.input_file.read_text()
+        if is_xml:
+            etree = ET.ElementTree(ET.fromstring(text))
+            self.stored_data = self.xml_to_dict(etree)
+            if not (self.stored_data['pv'] or self.stored_data['formula']):
+                raise FileNotFoundError(f"Incorrect input file format: {self.input_file}")
+        else:
+            self.stored_data = json.loads(text)
+            if not self.stored_data['curves']:
+                raise FileNotFoundError(f"Incorrect input file format: {self.input_file}")
+
+        return self.stored_data
+
+    def export_file(self, file_name: Union[str, Path] = None, output_data: Union[Dict, PyDMTimePlot] = None) -> None:
+        """Export the provided Archive Viewer save data to the provided file.
+        The file to export to should be of type '.pyav'. The provided data can
+        be either a dictionary or a PyDMTimePlot object. If no data is provided,
+        then the converter's previously imported data is exported.
+
+        Parameters
+        ----------
+        file_name : str or pathlib.Path
+            The absolute file path of the file that save data should be written
+            to. Should be of file type '.pyav'.
+        output_data : dict or PyDMTimePlot, optional
+            The data that should be exported, by default uses previously imported data
+
+        Raises
+        ------
+        FileNotFoundError
+            If the provided file name does not match the expected output file type '.pyav'
+        ValueError
+            If no output data is provided and the converter hasn't imported data previously
+        """
+        if file_name:
+            self.output_file = Path(file_name)
+        if not self.output_file.suffix:
+            self.output_file = self.output_file.with_suffix(".pyav")
+        elif not self.output_file.match("*.pyav"):
+            raise FileNotFoundError(f"Incorrect output file format: {self.output_file.suffix}")
+
+        if not output_data:
+            if not self.stored_data:
+                raise ValueError("Output data is required but was not provided "
+                                 "and the 'stored_data' property is not populated.")
+            output_data = self.stored_data
+        elif isinstance(output_data, PyDMTimePlot):
+            output_data = self.get_plot_data(output_data)
+
+        for obj in output_data['y-axes'] + output_data['curves']:
+            for k, v in obj.copy().items():
+                if v is None:
+                    del obj[k]
+
+        with open(self.output_file, 'w') as f:
+            json.dump(output_data, f, indent=4)
+
+    def convert_data(self, data_in: Dict = {}) -> Dict:
+        """Convert the inputted data from being formatted for the Java Archive
+        Viewer to a format used by the PyDM Archive Viewer. This is accomplished
+        by converting one dictionary structure to another.
+
+        Parameters
+        ----------
+        data_in : dict, optional
+            The input data to be converted, by default uses previously imported data
+
+        Returns
+        -------
+        dict
+            The converted data in a format that can be used by the PyDM Archive Viewer
+        """
+        if not data_in:
+            data_in = self.stored_data
+
+        converted_data = {}
+
+        converted_data['archiver_url'] = data_in.get("connection_parameter",
+                                                     getenv("PYDM_ARCHIVER_URL"))
+        converted_data['archiver_url'] = converted_data['archiver_url'].replace("pbraw://", "http://")
+
+        legend_dict = data_in['legend_configuration']
+        legend_dict['show_curve_name'] = legend_dict['show_ave_name']
+        del legend_dict['show_ave_name']
+
+        converted_data['plot'] = {'title': data_in['plot_title'],
+                                  'legend': legend_dict}
+
+        converted_data['time_axis'] = data_in['time_axis'][0]
+        converted_data['y-axes'] = []
+        for axis_in in data_in['range_axis']:
+            ax_dict = {'name': axis_in['name'],
+                       'label': axis_in['name'],
+                       'minRange': axis_in['min'],
+                       'maxRange': axis_in['max'],
+                       'orientation': axis_in['location'],
+                       'logMode': axis_in['type'] != "normal"}
+            filtered_dict = self.remove_null_values(ax_dict)
+            converted_data['y-axes'].append(filtered_dict)
+
+        converted_data['curves'] = []
+        for pv_in in data_in['pv']:
+            color = self.srgb_to_qColor(pv_in['color'])
+            pv_dict = {'name': pv_in['name'],
+                       'channel': pv_in['name'],
+                       'yAxisName': pv_in['range_axis_name'],
+                       'lineWidth': float(pv_in['draw_width']),
+                       'color': color.name(),
+                       'thresholdColor': color.name()}
+            filtered_dict = self.remove_null_values(pv_dict)
+            converted_data['curves'].append(filtered_dict)
+
+        for formula_in in data_in['formula']:
+            # TODO convert formulas once formulas are implemented for ArchiveViewer
+            pass
+
+        self.stored_data = converted_data
+        return self.stored_data
+
+    @staticmethod
+    def xml_to_dict(xml: ET.ElementTree) -> Dict:
+        """Convert an XML ElementTree containing an Archive Viewer save
+        file to a dictionary for easier use
+
+        Parameters
+        ----------
+        xml : ET.ElementTree
+            The XML ElementTree object read from the file
+
+        Returns
+        -------
+        dict
+            The data in a dictionary format
+        """
+        data_dict = {'connection_parameter': '',
+                    'plot_title': '',
+                    'legend_configuration': {},
+                    'time_axis': [],
+                    'range_axis': [],
+                    'pv': [],
+                    'formula': []}
+
+        data_dict['connection_parameter'] = xml.find("connection_parameter").text
+        data_dict['plot_title'] = xml.find("plot_title").text
+        data_dict['legend_configuration'] = xml.find("legend_configuration").attrib
+
+        for key in ("time_axis", "range_axis", "pv", "formula"):
+            for element in xml.findall(key):
+                ele_dict = element.attrib
+                ele_dict |= {sub_ele.tag: sub_ele.text for sub_ele in element}
+                data_dict[key].append(ele_dict)
+
+        return data_dict
+
+    @staticmethod
+    def get_plot_data(plot: PyDMTimePlot) -> Dict:
+        """Extract plot, axis, and curve data from a PyDMTimePlot object"""
+        output_dict = {'archiver_url': getenv("PYDM_ARCHIVER_URL"),
+                       'plot': {},
+                       'time_axis': {},
+                       'y-axes': [],
+                       'curves': []}
+
+        [start_ts, end_ts] = plot.getXAxis().range
+        start_dt = datetime.fromtimestamp(start_ts)
+        end_dt = datetime.fromtimestamp(end_ts)
+
+        output_dict['time_axis'] = {'name': "Main Time Axis",
+                                    'start': start_dt.isoformat(sep=' ', timespec='seconds'),
+                                    'end': end_dt.isoformat(sep=' ', timespec='seconds'),
+                                    'location': "bottom"}
+
+        for a in plot.getYAxes():
+            axis_dict = json.loads(a, object_pairs_hook=OrderedDict)
+            output_dict['y-axes'].append(axis_dict)
+
+        for c in plot.getCurves():
+            curve_dict = json.loads(c, object_pairs_hook=OrderedDict)
+            if not curve_dict['channel']:
+                continue
+            output_dict['curves'].append(curve_dict)
+
+        return output_dict
+
+    @staticmethod
+    def srgb_to_qColor(srgb: str) -> QColor:
+        """Convert RGB strings to QColors. The string is a 32-bit
+        integer containing the aRGB values of a color. (e.g. #FF0000 or -65536)
+
+        Parameters
+        ----------
+        srgb : str
+            Either a hex value or a string containing a signed 32-bit integer
+
+        Returns
+        -------
+        QColor
+            A QColor object storing the color described in the string
+        """
+        if not srgb:
+            return QColor()
+        elif srgb[0] != '#':
+            rgb_int = int(srgb) & 0xFFFFFFFF
+            srgb = f"#{rgb_int:08X}"
+        return QColor(srgb)
+
+    @staticmethod
+    def remove_null_values(dict_in: Dict) -> Dict:
+        """Remove all key-value pairs from a given dictionary where the value is None"""
+        dict_out = dict_in.copy()
+        for k, v in dict_in.items():
+            if v is None:
+               del dict_out[k]
+        return dict_out
+
+
+def main(input_file: Path = None, output_file: Path = None, overwrite: bool = False, clean: bool = False):
+    # Check that the input file is usable
+    if not input_file:
+        raise FileNotFoundError("Input file not provided")
+    elif not input_file.is_file():
+        raise FileNotFoundError(f"Data file not found: {input_file}")
+    elif not input_file.match("*.xml"):
+        raise FileNotFoundError(f"Incorrect input file format: {input_file}")
+
+    # Check that the output file is usable
+    if not output_file:
+        output_file = input_file.with_suffix(".pyav")
+    elif not output_file.suffix:
+        output_file = output_file.with_suffix(".pyav")
+    elif not output_file.match("*.pyav"):
+        raise FileNotFoundError(f"Incorrect output file format: {output_file}")
+
+    # Check if file exists, and if it does if the overwrite flag is used
+    if output_file.is_file() and not overwrite:
+        raise FileNotFoundError(f"Output file exists but overwrite not enabled: {output_file}")
+
+    # Complete the requested conversion
+    converter = ArchiveViewerFileConverter()
+
+    converter.import_file(input_file)
+    converter.convert_data()
+    converter.export_file(output_file)
+
+    # Remove the input file if requested
+    if clean:
+        input_file.unlink()
+        logger.debug(f"Removing input file: {input_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    class PathAction(Action):
+        def __call__(self, parser: ArgumentParser, namespace: Namespace, values: str, option_string: str = None) -> None:
+            """Convert filepath string from argument into  a pathlib.Path object"""
+            new_path = path.expandvars(values)
+            new_path = Path(new_path).expanduser()
+            new_path = new_path.resolve()
+            setattr(namespace, self.dest, new_path)
+
+    parser = ArgumentParser(prog="Archive Viewer File Converter",
+                            description="Convert files used by the Java Archive"
+                            " Viewer to a file format that can be used with the"
+                            " newer PyDM Archive Viewer.")
+    parser.add_argument("input_file",
+                        action=PathAction,
+                        type=str,
+                        help="Path to the file to be converted")
+    parser.add_argument("--output_file", "-o",
+                        action=PathAction,
+                        type=str,
+                        help="Path to the output file (defaults to input file name)")
+    parser.add_argument("--overwrite", "-w",
+                        action="store_true",
+                        help="Overwrite the target file if it exists")
+    parser.add_argument("--clean",
+                        action="store_true",
+                        help="Remove the input file after successful conversion")
+    args = parser.parse_args()
+
+    try:
+        main(**vars(args))
+    except Exception as e:
+        logger.error(e)

--- a/archive_viewer/config.json
+++ b/archive_viewer/config.json
@@ -1,4 +1,5 @@
 {
+    "save_file_dir": "$PHYSICS_DATA/ArchiveViewer/",
     "archivers": {
         "LCLS": "http://lcls-archapp.slac.stanford.edu"
     },

--- a/archive_viewer/config.py
+++ b/archive_viewer/config.py
@@ -1,13 +1,19 @@
 import os
 from json import load
+from pathlib import Path
 from logging import getLogger
 from qtpy.QtGui import QColor
 
 
+config_file = Path(__file__).parent / "config.json"
+with config_file.open() as f:
+    loaded_json = load(f)
+
 logger = getLogger(__name__)
 
-with open("config.json") as f:
-    loaded_json = load(f)
+save_file_dir = Path(os.path.expandvars(loaded_json['save_file_dir']))
+if not save_file_dir.is_dir():
+    save_file_dir = Path.home()
 
 archiver_urls = loaded_json['archivers']
 if not archiver_urls:

--- a/archive_viewer/config.py
+++ b/archive_viewer/config.py
@@ -13,7 +13,9 @@ logger = getLogger(__name__)
 
 save_file_dir = Path(os.path.expandvars(loaded_json['save_file_dir']))
 if not save_file_dir.is_dir():
+    logger.warning(f"Config file's save_file_dir path does not exist: {save_file_dir}")
     save_file_dir = Path.home()
+    logger.warning(f"Setting save_file_dir to home: {save_file_dir}")
 
 archiver_urls = loaded_json['archivers']
 if not archiver_urls:

--- a/archive_viewer/mixins/__init__.py
+++ b/archive_viewer/mixins/__init__.py
@@ -1,2 +1,3 @@
-from .traces_table import TracesTableMixin
+from .file_io import FileIOMixin
 from .axis_table import AxisTableMixin
+from .traces_table import TracesTableMixin

--- a/archive_viewer/mixins/file_io.py
+++ b/archive_viewer/mixins/file_io.py
@@ -1,0 +1,69 @@
+from os import getenv
+from pathlib import Path
+from datetime import datetime
+from urllib.parse import urlparse
+from qtpy.QtWidgets import (QMessageBox, QFileDialog)
+from config import (logger, save_file_dir)
+from av_file_convert import ArchiveViewerFileConverter
+
+
+class FileIOMixin:
+    def file_io_init(self):
+        self.converter = ArchiveViewerFileConverter()
+
+        self.io_path = save_file_dir
+
+        self.ui.test_export_btn.clicked.connect(self.export_save_file)
+        self.ui.test_import_btn.clicked.connect(self.import_save_file)
+
+    def export_save_file(self):
+        file_name, _ = QFileDialog.getSaveFileName(self, "Save Archive Viewer",
+                                                   str(self.io_path),
+                                                   "Python Archive Viewer (*.pyav)")
+        file_name = Path(file_name)
+        if file_name.is_dir():
+            logger.warning("No file name provided")
+            return
+
+        try:
+            self.io_path = file_name.parent
+            self.converter.export_file(file_name, self.ui.archiver_plot)
+        except FileNotFoundError as e:
+            logger.error(e)
+            self.export_save_file()
+
+    def import_save_file(self):
+        file_name, _ = QFileDialog.getOpenFileName(self, "Open Archive Viewer",
+                                                   str(self.io_path),
+                                                   "Python Archive Viewer (*.pyav);;"
+                                                   + "Java Archive Viewer (*.xml);;"
+                                                   + "All Files (*)")
+        file_name = Path(file_name)
+        if not file_name.is_file():
+            return
+
+        try:
+            file_data = self.converter.import_file(file_name)
+            if self.converter.import_is_xml():
+                file_data = self.converter.convert_data(file_data)
+            self.io_path = file_name.parent
+        except FileNotFoundError as e:
+            logger.error(e)
+            self.import_save_file()
+            return
+
+        import_url = urlparse(file_data['archiver_url'])
+        archiver_url = urlparse(getenv("PYDM_ARCHIVER_URL"))
+        if import_url.hostname != archiver_url.hostname:
+            ret = QMessageBox.warning(self,
+                                      "Import Error",
+                                      "The config file you tried to open reads from a different archiver.\n"
+                                      f"\nCurrent archiver is:\n{archiver_url.hostname}\n"
+                                      f"\nAttempted import uses:\n{import_url.hostname}",
+                                      QMessageBox.Ok | QMessageBox.Cancel,
+                                      QMessageBox.Ok)
+            if ret == QMessageBox.Cancel:
+                return
+
+        self.axis_table_model.set_model_axes(file_data['y-axes'])
+        self.curves_model.set_model_curves(file_data['curves'])

--- a/archive_viewer/mixins/file_io.py
+++ b/archive_viewer/mixins/file_io.py
@@ -11,12 +11,8 @@ from av_file_convert import ArchiveViewerFileConverter
 
 class FileIOMixin:
     def file_io_init(self):
-        self.converter = ArchiveViewerFileConverter()
-
         self.io_path = save_file_dir
-
-        self.ui.test_export_btn.clicked.connect(self.export_save_file)
-        self.ui.test_import_btn.clicked.connect(self.import_save_file)
+        self.converter = ArchiveViewerFileConverter()
 
     def export_save_file(self):
         """Prompt the user for a file to export config data to"""

--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -1,4 +1,5 @@
 from typing import (Dict, Any)
+from qtpy import sip
 from qtpy.QtCore import (Slot, QPoint, QModelIndex, QObject)
 from qtpy.QtWidgets import (QHeaderView, QMenu, QAction, QTableView, QDialog,
                             QVBoxLayout, QGridLayout, QLineEdit, QPushButton)
@@ -123,8 +124,12 @@ class TracesTableMixin:
         axis_name : str
             The name of the new axis the curve should be on
         """
+        if not axis_name:
+            return
+        # Get the curve and check if it has been deleted
         curve = self.curves_model.curve_at_index(row)
-        self.ui.archiver_plot.plotItem.linkDataToAxis(curve, axis_name)
+        if not sip.isdeleted(curve):
+            self.ui.archiver_plot.plotItem.linkDataToAxis(curve, axis_name)
 
 
 class PVContextMenu(QMenu):

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import (Any, List, Dict)
 from qtpy.QtCore import (Qt, QVariant, QPersistentModelIndex, QModelIndex)
-from pydm.widgets.baseplot import BasePlot, BasePlotAxisItem
+from pydm.widgets.baseplot import (BasePlot, BasePlotAxisItem)
 from pydm.widgets.axis_table_model import BasePlotAxesModel
 
 
@@ -92,6 +92,34 @@ class ArchiverAxisModel(BasePlotAxesModel):
         new_axis = self.get_axis(-1)
         row = self.rowCount() - 1
         self.attach_range_changed(row, new_axis)
+
+    def set_model_axes(self, axes: List[Dict]) -> None:
+        key_translate = {"minRange": "min_range",
+                         "maxRange": "max_range",
+                         "autoRange": "enable_auto_range",
+                         "logMode": "log_mode"}
+        cleaned_axes = []
+        for a in axes:
+            clean_a = {}
+            for k, v in a.items():
+                if v is None:
+                    continue
+                elif k in key_translate:
+                    new_k = key_translate[k]
+                    clean_a[new_k] = a[k]
+                else:
+                    clean_a[k] = a[k]
+            cleaned_axes.append(clean_a)
+
+        self.beginResetModel()
+        self._plot.clearAxes()
+
+        for a in cleaned_axes:
+            self._plot.addAxis(None, **a)
+
+        for row, axis in enumerate(self._plot._axes):
+            self.attach_range_changed(row, axis)
+        self.endResetModel()
 
     def removeAtIndex(self, index: QModelIndex) -> None:
         """Removes the axis at the given table index.

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -94,13 +94,22 @@ class ArchiverAxisModel(BasePlotAxesModel):
         self.attach_range_changed(row, new_axis)
 
     def set_model_axes(self, axes: List[Dict]) -> None:
-        key_translate = {"minRange": "min_range",
-                         "maxRange": "max_range",
-                         "autoRange": "enable_auto_range",
-                         "logMode": "log_mode"}
+        """Given a list of dictionaries containing axis data, clear the
+        plot's axes, and set all new axes based on the provided axis data.
+
+        Parameters
+        ----------
+        axes : List[Dict]
+            Axis properties to be set for all new axes on the plot
+        """
+        key_translate = {'minRange': "min_range",
+                         'maxRange': "max_range",
+                         'autoRange': "enable_auto_range",
+                         'logMode': "log_mode"}
         cleaned_axes = []
         for a in axes:
-            clean_a = {}
+            clean_a = {'name': f"New Axis {len(cleaned_axes) + 1}",
+                       'orientation': "left"}
             for k, v in a.items():
                 if v is None:
                     continue
@@ -113,13 +122,12 @@ class ArchiverAxisModel(BasePlotAxesModel):
 
         self.beginResetModel()
         self._plot.clearAxes()
-
         for a in cleaned_axes:
             self._plot.addAxis(None, **a)
+        self.endResetModel()
 
         for row, axis in enumerate(self._plot._axes):
             self.attach_range_changed(row, axis)
-        self.endResetModel()
 
     def removeAtIndex(self, index: QModelIndex) -> None:
         """Removes the axis at the given table index.

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -1,9 +1,9 @@
-from typing import (Any, Optional)
+from typing import (Any, List, Dict, Optional)
+from qtpy.QtGui import QColor
 from qtpy.QtCore import (QObject, QModelIndex, Qt)
 from pydm.widgets.baseplot import BasePlot
 from pydm.widgets.archiver_time_plot import ArchivePlotCurveItem
 from pydm.widgets.archiver_time_plot_editor import PyDMArchiverTimePlotCurvesModel
-from qtpy.QtGui import QColor
 from widgets import ColorButton
 from table_models import ArchiverAxisModel
 
@@ -106,6 +106,23 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self.beginInsertRows(QModelIndex(), len(self._plot._curves), len(self._plot._curves))
         self._plot.addYChannel(y_channel=address, name=name, color=color, useArchiveData=True, yAxisName=y_axis.name)
         self.endInsertRows()
+
+    def set_model_curves(self, curves: List[Dict]) -> None:
+        self.beginResetModel()
+        self._plot.clearCurves()
+        self._row_names = []
+
+        for c in curves:
+            for k, v in c.items():
+                if v is None:
+                    del c[k]
+            c['y_channel'] = c['channel']
+            del c['channel']
+            self._plot.addYChannel(**c)
+            self._row_names.append(self.next_header())
+        self.append()
+
+        self.endResetModel()
 
     def removeAtIndex(self, index: QModelIndex) -> None:
         """Removes the curve at the given table index.

--- a/launch_archive_viewer.bash
+++ b/launch_archive_viewer.bash
@@ -12,7 +12,7 @@ exit_abnormal(){
     exit 1
 }
 
-pydm --hide-nav-bar --hide-status-bar --hide-menu-bar \
+pydm --hide-nav-bar --hide-status-bar \
     archive_viewer.py
 
 exit 0


### PR DESCRIPTION
Create a tool to manage importing, exporting, and converting Archive Viewer config files. The tool works as a standalone CLI tool as well as an importable module.

The import & export capabilities are straight forward: given a filename either read in the data or write saved data to the file. The imported file can be of 2 types (.xml and .pyav), but the file extension is ignored if it is in the right format. The tool allows for converting from Java-based Archive Viewer config files to PyDM-based Archive Viewer files.

This Pull Request also implements importing/exporting into the Archive Viewer, making use of the tool described above. File IO is attached to 2 buttons on the application marked "Test Import" and "Test Export". This functionality should be moved eventually.

Changes to the .gitignore to ignore save files (while testing).