### PR TITLE
ENH: Fixing Axes functionality on the Archive Viewer

### DIFF
--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -41,6 +41,12 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
 
         app = QApplication.instance()
         app.setStyle(CenterCheckStyle())
+        self.axis_table_model.reset_everything.connect(self.resetPlot)
+
+    @Slot()
+    def resetPlot(self):
+        self.axis_table_model.set_model_axes()
+        self.curves_model.set_model_curves()
 
     def file_menu_items(self) -> dict:
         """Add export & import functionality to File menu; override Display.file_menu_items"""

--- a/archive_viewer/mixins/axis_table.py
+++ b/archive_viewer/mixins/axis_table.py
@@ -14,7 +14,6 @@ class AxisTableMixin:
     def axis_table_init(self) -> None:
         """Initializer for the Axis Table Model and Table View."""
         self.axis_table_model = ArchiverAxisModel(self.ui.archiver_plot, self)
-
         self.ui.time_axis_tbl.setModel(self.axis_table_model)
 
         hdr = self.ui.time_axis_tbl.horizontalHeader()

--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -34,7 +34,6 @@ class TracesTableMixin:
         """Set column delegates for the Traces table to display widgets."""
         axis_col = self.curves_model.getColumnIndex("Y-Axis Name")
         axis_combo_del = ComboBoxDelegate(self.ui.traces_tbl, self.axis_table_model)
-        axis_combo_del.sigTextChange.connect(self.axis_change)
         self.ui.traces_tbl.setItemDelegateForColumn(axis_col, axis_combo_del)
 
         color_col = self.curves_model.getColumnIndex("Color")
@@ -111,20 +110,6 @@ class TracesTableMixin:
         if index.isValid() and not is_color:
             self.menu.selected_index = index
             self.menu.popup(table.viewport().mapToGlobal(pos))
-
-    @Slot(int, str)
-    def axis_change(self, row: int, axis_name: str) -> None:
-        """Slot for connecting a curve to a specified axis.
-
-        Parameters
-        ----------
-        row : int
-            The row of the table associated with the curve changed
-        axis_name : str
-            The name of the new axis the curve should be on
-        """
-        curve = self.curves_model.curve_at_index(row)
-        self.ui.archiver_plot.plotItem.linkDataToAxis(curve, axis_name)
 
 
 class PVContextMenu(QMenu):

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -69,8 +69,7 @@ class ArchiverAxisModel(BasePlotAxesModel):
             return QVariant()
         # Specifically the Hidden column must be affected in axis_model as opposed to elsewhere
         elif role == Qt.CheckStateRole and self._column_names[index.column()] == "Hidden":
-            axis = self.plot._axes[index.row()]
-            self.setHidden(axis, bool(value))
+            self.plot._axes[index.row()].setHidden(bool(value))
             return True
         elif role == Qt.CheckStateRole and index.column() in self.checkable_col:
             return super().setData(index, value, Qt.EditRole)
@@ -126,12 +125,6 @@ class ArchiverAxisModel(BasePlotAxesModel):
         index : QModelIndex
             An index in the row to be hidde.
         """
-        # Hide all curves
-        for curve in axis._curves:
-            if hidden:
-                curve.hide()
-            else:
-                curve.show()
         # Hide the axis
         axis.setHidden(shouldHide=hidden)
 

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -107,9 +107,14 @@ class ArchiverAxisModel(BasePlotAxesModel):
         index : QModelIndex
             An index in the row to be removed.
         """
+        if not index.isValid() or self.rowCount() == 1:
+            return False
         axis = self.get_axis(index.row())
         while axis._curves:
             curve = axis._curves[0]
+            if curve == self._plot._curves[-1] or len(self._plot._curves) == 1:
+                # Reasons for us to in fact not delete this axis despite manual attempt by the user
+                return
             self.remove_curve.emit(curve)
         super().removeAtIndex(index)
 

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -107,10 +107,9 @@ class ArchiverAxisModel(BasePlotAxesModel):
         # if self.rowCount() <= 1:
         #     self.append()
         axis = self.get_axis(index.row())
-        if hasattr(axis, "_curves"):
-            for i in range(len(axis._curves)):
-                curve = axis._curves[0]
-                self.remove_curve.emit(curve)
+        while axis._curves:
+            curve = axis._curves[0]
+            self.remove_curve.emit(curve)
         super().removeAtIndex(index)
 
     def setHidden(self, axis: BasePlotAxisItem, hidden: bool) -> None:

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -117,7 +117,8 @@ class ArchiverAxisModel(BasePlotAxesModel):
         cleaned_axes = []
         for a in axes:
             clean_a = {'name': f"Axis {len(cleaned_axes) + 1}",
-                       'orientation': "left"}
+                       'orientation': "left",
+                       'label': f"Axis {len(cleaned_axes) + 1}"}
             for k, v in a.items():
                 if v is None:
                     continue
@@ -128,7 +129,8 @@ class ArchiverAxisModel(BasePlotAxesModel):
                     clean_a[k] = a[k]
             cleaned_axes.append(clean_a)
         clean_a = {'name': f"Axis {len(cleaned_axes) + 1}",
-                       'orientation': "left"}
+                       'orientation': "left",
+                       'label': f"Axis {len(cleaned_axes) + 1}"}
         cleaned_axes.append(clean_a)
         logger.debug("Clearing axes model")
         self.beginResetModel()

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -87,9 +87,12 @@ class ArchiverAxisModel(BasePlotAxesModel):
             The name for the new axis item. If none is passed in, the
             axis is named "Axis <row_count>".
         """
-        self.axis_count += 1
         if not name:
-            name = f"Axis {self.axis_count}"
+            axis_count = self.rowCount() + 1
+            name = f"Axis {axis_count}"
+            while name in self.plot.plotItem.axes:
+                axis_count += 1
+                name = f"Axis {axis_count}"
         super().append(name)
         new_axis = self.get_axis(-1)
         new_axis.setLabel(name, color="black")
@@ -104,8 +107,6 @@ class ArchiverAxisModel(BasePlotAxesModel):
         index : QModelIndex
             An index in the row to be removed.
         """
-        # if self.rowCount() <= 1:
-        #     self.append()
         axis = self.get_axis(index.row())
         while axis._curves:
             curve = axis._curves[0]
@@ -121,14 +122,11 @@ class ArchiverAxisModel(BasePlotAxesModel):
             An index in the row to be hidde.
         """
         # Hide all curves
-        if hasattr(axis, "_curves"):
-            for curve in axis._curves:
-                if hidden:
-                    curve.hidden = True
-                    curve.hide()
-                else:
-                    curve.hidden = False
-                    curve.show()
+        for curve in axis._curves:
+            if hidden:
+                curve.hide()
+            else:
+                curve.show()
         # Hide the axis
         axis.setHidden(shouldHide=hidden)
 

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -132,7 +132,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         logger.debug("Finished setting curve data")
         return ret_code
 
-    def append(self, address: Optional[str] = None, name: Optional[str] = None, color: Optional[QColor] = None) -> None:
+    def append(self, address: Optional[str] = None, name: Optional[str] = None, color: Optional[QColor] = None, addAxis=True) -> None:
         """Add a new curve item to plot and the data model.
 
         Parameters
@@ -145,7 +145,8 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             The curve's color on the plot.
         """
         logger.debug("Adding new empty curve to plot")
-        self._axis_model.append()
+        if addAxis:
+            self._axis_model.append()
         y_axis = self._axis_model.get_axis(-1)
         if not color:
             color = ColorButton.index_color(self.rowCount())
@@ -182,7 +183,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             del c['channel']
             self._plot.addYChannel(**c)
             self._row_names.append(self.next_header())
-        self.append()
+        self.append(addAxis=False)
         self.endResetModel()
         logger.debug("Finished setting curves model")
 

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -68,16 +68,16 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         index = self.index(self._plot._curves.index(curve),0)
         if column_name == "Channel":
             curve.show()
-            self._axis_model.plot.plotItem.axes[curve.y_axis_name]["item"].show()
-
+            if not curve.name():
+                curve.setData(name=str(value))
+            self.plot.plotItem.autoVisible(curve.y_axis_name)
             if value == curve.address:
                 return True
 
             [ch.disconnect() for ch in curve.channels() if ch]
             curve.address = str(value)
             [ch.connect() for ch in curve.channels() if ch]
-            if not curve.name():
-                curve.setData(name=str(value))
+
 
             if value and self._plot._curves[-1] is curve:
                 self.append()

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -7,7 +7,7 @@ from pydm.widgets.archiver_time_plot_editor import PyDMArchiverTimePlotCurvesMod
 from config import logger
 from widgets import ColorButton
 from table_models import ArchiverAxisModel
-from config import logger
+from qtpy import sip
 
 class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
     """Model used for storing and editing archiver time plot curves.
@@ -73,6 +73,8 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         logger.debug(f"Setting {column_name} data for curve {curve.address}")
         ret_code = False
         index = self.index(self._plot._curves.index(curve),0)
+        if sip.isdeleted(curve):
+            return False
         if column_name == "Channel":
             curve.show()
             if not curve.name():
@@ -158,7 +160,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             self._axis_model.plot.plotItem.axes[y_axis.name]["item"].hide()
         logger.debug("Finished adding new empty curve to plot")
 
-    def set_model_curves(self, curves: List[Dict]) -> None:
+    def set_model_curves(self, curves: List[Dict] = []) -> None:
         """Reset model curves to given list of curve properties.
 
         Parameters

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -263,6 +263,9 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         """Necessary specifically for when an axis is deleted
         To properly delete all of its connected curves
 
+        Parameters
+        ----------
+
         curve: BasePlotCurveItem
             The curve we want to delete from the model"""
         ind = self._plot._curves.index(curve)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -126,7 +126,6 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             ret_code = True
         else:
             ret_code = super(ArchiverCurveModel, self).set_data(column_name, curve, value)
-        #After messing with the data, just cleanly redraw everything
         self.plot.plotItem.autoVisible(curve.y_axis_name)
         logger.debug("Finished setting curve data")
         return ret_code
@@ -149,9 +148,8 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         if not color:
             color = ColorButton.index_color(self.rowCount())
         self._row_names.append(self.next_header())
-        #          KLYS:LI22:31:KVAC
         self.beginInsertRows(QModelIndex(), len(self._plot._curves), len(self._plot._curves))
-        #by default, add a blank archivePlotCurveItem such that there's an empty row to add PVs or formulas to.
+        # By default, add a blank archivePlotCurveItem such that there's an empty row to add PVs or formulas to.
         self._plot.addYChannel(y_channel=address, name=name, color=color, useArchiveData=True, yAxisName=y_axis.name)
         self.endInsertRows()
         self._plot._curves[-1].hide()
@@ -258,9 +256,12 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         return self._plot.curveAtIndex(index)
 
     @Slot(object)
-    def remove_curve(self, curve: BasePlotCurveItem):
+    def remove_curve(self, curve: BasePlotCurveItem) -> None:
         """Necessary specifically for when an axis is deleted
-        To properly delete all of its connected curves"""
+        To properly delete all of its connected curves
+
+        curve: BasePlotCurveItem
+            The curve we want to delete from the model"""
         ind = self._plot._curves.index(curve)
         ind = self.index(ind, 0)
         self.removeAtIndex(ind)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -70,7 +70,6 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             curve.show()
             if not curve.name():
                 curve.setData(name=str(value))
-            self.plot.plotItem.autoVisible(curve.y_axis_name)
             if value == curve.address:
                 return True
 
@@ -109,6 +108,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         else:
             ret_code = super(ArchiverCurveModel, self).set_data(column_name, curve, value)
         #After messing with the data, just cleanly redraw everything
+        self.plot.plotItem.autoVisible(curve.y_axis_name)
         self._plot.requestDataFromArchiver()
         self._plot.set_needs_redraw()
         self._plot.redrawPlot()

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -116,6 +116,7 @@ class EditorDelegate(QStyledItemDelegate):
         """Slot called when the delegate's model will be reset. Closes all
         persistent editors in the delegate.
         """
+
         for editor in self.editor_list:
             editor_pos = editor.pos()
             index = self.parent().indexAt(editor_pos)
@@ -404,6 +405,19 @@ class ScientificNotationDelegate(EditorDelegate):
 
         data = float(text)
         model.setData(index, data, Qt.EditRole)
+
+    @Slot()
+    def reset_editors(self) -> None:
+        """Slot called when the delegate's model will be reset. Closes all
+        persistent editors in the delegate.
+        """
+        for editor in self.editor_list:
+            editor_pos = editor[0].pos()
+            index = self.parent().indexAt(editor_pos)
+
+            editor[0].deleteLater()
+            self.parent().closePersistentEditor(index)
+        self.editor_list = []
 
 
 class DeleteRowDelegate(EditorDelegate):

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -303,45 +303,7 @@ class DeleteRowDelegate(QStyledItemDelegate):
     def setModelData(self, _: QPushButton, model: QAbstractTableModel, index: QModelIndex) -> None:
         """When the setModelData slot is triggered, the row is removed."""
         model.removeAtIndex(index)
-class InsertPVDelegate(QStyledItemDelegate):
-    """InsertPVDelegate is a QStyledItemDelegate to display a persistent
-    QPushButton widget on the FormulaDialog that allow's the user to insert the PV.
 
-    Parameters
-    ----------
-    parent : FormulaDialog
-        The parent object for the InsertPVDelegate. Should be the
-        associated QTableView
-    """
-    button_clicked = Signal(str)
-    def __init__(self, parent: QTableView, model: QAbstractItemModel) -> None:
-        super().__init__(parent)
-        self.editor_list = []
-        self.model = model
-
-    def initStyleOption(self, option: QStyleOptionViewItem, index: QModelIndex) -> None:
-        """Initialize a QPushButton to insert the table's header."""
-        logger.debug("called method: InsertPVDelegate.initStyleOption")
-        if index.row() >= len(self.editor_list):
-            editor = QPushButton(self.parent())
-            editor.setText("Insert")
-            editor.setToolTip("Insert PV")
-            #We don't want to allow people to select the button, only click it
-            editor.setFocusPolicy(Qt.NoFocus)
-            editor.pressed.connect(lambda: self.button_clicked.emit("{"+ self.model._row_names[index.row()]+"}"))
-            self.editor_list.append(editor)
-            self.parent().setIndexWidget(index, editor)
-
-        return super().initStyleOption(option, index)
-
-    def destroyEditor(self, editor: QWidget, index: QModelIndex) -> None:
-        """Destroy the editor for a defined index."""
-        if index.row() < len(self.editor_list):
-            logger.debug(f"Removing {self.editor_list[index.row()]} from delegate")
-            self.editor_list[index.row()].deleteLater()
-            del self.editor_list[index.row()]
-            return
-        return super().destroyEditor(editor, index)
 
 class FloatDelegate(QStyledItemDelegate):
     """FloatDelegate is a QStyledItemDelegate to display a

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -508,6 +508,8 @@ class ComboBoxDelegate(QStyledItemDelegate):
             elif isinstance(self.data_source, QAbstractItemModel):
                 editor.setModel(self.data_source)
                 editor.setModelColumn(0)
+                value = index.data(Qt.DisplayRole)
+                editor.setCurrentText(str(value))
 
             editor.setFocusPolicy(Qt.StrongFocus)
             editor.setContextMenuPolicy(Qt.CustomContextMenu)

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -99,6 +99,7 @@ class ComboBoxDelegate(QStyledItemDelegate):
         """Initialize a QComboBox for use in the Table View."""
         if index.row() >= len(self.editor_list):
             editor = QComboBox()
+
             logger.debug(f"Setting input to {self.data_source}")
             if isinstance(self.data_source, dict):
                 editor.addItems(self.data_source.keys())


### PR DESCRIPTION
Builds on #24 

Requires the pydm PR to go through, but allows the user to cleanly navigate adding, removing, and hiding axes; as well as hiding/removing curves and it properly hiding their axes. Finally, it defaults new curves to the correct axes upon creation and allows for easy switching between axes.