### PR TITLE
ENH: Style column in traces_table sets curve's stepMode

### DIFF
--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -16,8 +16,6 @@ class TracesTableMixin:
     def traces_table_init(self) -> None:
         """Initialize the Traces table model and section."""
         self.curves_model = ArchiverCurveModel(self, self.ui.archiver_plot, self.axis_table_model)
-        self.curves_model.append()
-
         self.ui.traces_tbl.setModel(self.curves_model)
 
         self.menu = PVContextMenu(self)
@@ -43,11 +41,8 @@ class TracesTableMixin:
         self.ui.traces_tbl.setItemDelegateForColumn(color_col, color_button_del)
 
         style_col = self.curves_model.getColumnIndex("Style")
-        style_del = PlotStyleColumnDelegate(self,
-                                       self.curves_model,
-                                       self.ui.traces_tbl)
-        style_del.toggleColumnVisibility()
-        self.ui.traces_tbl.setItemDelegateForColumn(style_col, style_del)
+        style_combo_del = ComboBoxDelegate(self.ui.traces_tbl, {"Direct": None, "Step": "right"})
+        self.ui.traces_tbl.setItemDelegateForColumn(style_col, style_combo_del)
 
         styles = BasePlotCurveItem.lines
         line_style_col = self.curves_model.getColumnIndex("Line Style")
@@ -68,22 +63,6 @@ class TracesTableMixin:
         symbol_size_col = self.curves_model.getColumnIndex("Symbol Size")
         symbol_size_del = ComboBoxDelegate(self.ui.traces_tbl, size_data)
         self.ui.traces_tbl.setItemDelegateForColumn(symbol_size_col, symbol_size_del)
-
-        bar_width_col = self.curves_model.getColumnIndex("Bar Width")
-        bar_width_del = FloatDelegate(self.ui.traces_tbl, init_range=(.1, 5))
-        self.ui.traces_tbl.setItemDelegateForColumn(bar_width_col, bar_width_del)
-
-        upper_limit_col = self.curves_model.getColumnIndex("Upper Limit")
-        upper_limit_del = FloatDelegate(self.ui.traces_tbl, init_range=(0, float("inf")))
-        self.ui.traces_tbl.setItemDelegateForColumn(upper_limit_col, upper_limit_del)
-
-        lower_limit_col = self.curves_model.getColumnIndex("Lower Limit")
-        lower_limit_del = FloatDelegate(self.ui.traces_tbl, init_range=(0, float("inf")))
-        self.ui.traces_tbl.setItemDelegateForColumn(lower_limit_col, lower_limit_del)
-
-        limit_color_col = self.curves_model.getColumnIndex("Limit Color")
-        limit_color_del = ColorButtonDelegate(self.ui.traces_tbl)
-        self.ui.traces_tbl.setItemDelegateForColumn(limit_color_col, limit_color_del)
 
         delete_col = self.curves_model.getColumnIndex("")
         delete_row_del = DeleteRowDelegate(self.ui.traces_tbl)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -23,9 +23,11 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
 
     def __init__(self, parent: Optional[QObject], plot: BasePlot, axis_model: ArchiverAxisModel) -> None:
         super(ArchiverCurveModel, self).__init__(plot, parent)
-        self._column_names = self._column_names[:6] + ("Style",) + self._column_names[6:] + ("",)
+        # Remove columns for bar width, limits, and thresholds. Bar graph plot style is unused
+        self._column_names = self._column_names[:6] + ("Style",) + self._column_names[6:10] + ("",)
         self._row_names = []
         self._axis_model = axis_model
+        self.append()
 
     def get_data(self, column_name: str, curve: ArchivePlotCurveItem) -> Any:
         """Get data from the model based on column name.
@@ -39,7 +41,10 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             The curve that data should be returned for.
         """
         if column_name == "Style":
-            return curve.plot_style
+            if curve.stepMode in ["right", "left", "center"]:
+                return "Step"
+            elif not curve.stepMode:
+                return "Direct"
         return super(ArchiverCurveModel, self).get_data(column_name, curve)
 
     def set_data(self, column_name: str, curve: ArchivePlotCurveItem, value: Any) -> bool:
@@ -77,7 +82,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
 
             ret_code = True
         elif column_name == "Style":
-            curve.plot_style = str(value)
+            curve.stepMode = value
             ret_code = True
         else:
             ret_code = super(ArchiverCurveModel, self).set_data(column_name, curve, value)


### PR DESCRIPTION
Relies on PR #19 and PyDM PR [#1096](https://github.com/slaclab/pydm/pull/1096)

Makes use of the Style column in the traces table. There are 2 options available to the user: Direct (default) and Step.

The Direct option is the same as what we've seen before: lines drawn directly from y-value to y-value.
The Step option will show horizontal lines extending to the right of y-values, continuing until a new y-value, where there will be a vertical line connecting the two. 

I also removed all of the columns used for thresholds & limits as those are unnecessary without the bar graph styling.