### PR TITLE
ENH: Macro & Argument Functionality

### DIFF
--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -1,4 +1,6 @@
 import os
+import argparse
+from typing import Tuple, List, Dict
 from logging import (Handler, LogRecord)
 from subprocess import run
 from qtpy.QtCore import Slot
@@ -7,6 +9,7 @@ from pydm import Display
 from config import (logger, datetime_pv)
 from mixins import (TracesTableMixin, AxisTableMixin, FileIOMixin)
 from styles import CenterCheckStyle
+from av_file_convert import PathAction
 
 
 class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
@@ -37,10 +40,16 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         plot_viewbox = self.ui.archiver_plot.plotItem.vb
         plot_viewbox.sigRangeChangedManually.connect(self.ui.cursor_scale_btn.click)
 
-    def file_menu_items(self) -> dict:
+        input_file, startup_pvs = self.parse_macros_and_args(macros, args)
+        if input_file:
+            self.import_save_file(input_file)
+        for p in startup_pvs:
+            self.curves_model.add_curve(p)
+
+    def menu_items(self) -> dict:
         """Add export & import functionality to File menu"""
-        return {"save": (self.export_save_file, "Ctrl+S"),
-                "load": (self.import_save_file, "Ctrl+L")}
+        return {"Export": (self.export_save_file, "Ctrl+S"),
+                "Import": (self.import_save_file, "Ctrl+L")}
 
     def configure_app(self):
         """UI changes to be made to the PyDMApplication"""
@@ -98,6 +107,61 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
             logger.debug("Disabling plot autoscroll, using mouse controls")
 
         self.ui.archiver_plot.setAutoScroll(enable_scroll, timespan)
+
+    def parse_macros_and_args(self, macros: Dict[str, str | list], args: List[str]) -> Tuple[str, list]:
+        """Parse user provided macros and args into lists of PVs to use on
+        startup or which file to import on startup
+
+        Parameters
+        ----------
+        macros : Dict[str, Union[str, List]]
+            Dictionary containing all of the macros passed into PyDM
+        args : List[str]
+            List of all arguments passed into the application to be parsed
+
+        Returns
+        -------
+        tuple
+            A tuple containing the file to import from and the list of PVs to use on startup
+        """
+        # Construct an argument parser for args
+        trace_parser = argparse.ArgumentParser(description="Trace\nThis is a PyDM application "
+                                               + "used to display archived and live pv data.",
+                                               formatter_class=argparse.RawTextHelpFormatter)
+        trace_parser.add_argument("-i", "--input_file",
+                                  action=PathAction,
+                                  type=str,
+                                  default="",
+                                  help="Absolute file path to import from;\n"
+                                  + "Alternatively can be provided as INPUT_FILE macro")
+        trace_parser.add_argument("-p", "--pvs",
+                                  type=str,
+                                  nargs='*',
+                                  default=[],
+                                  help="List of PVs to show on startup;\n"
+                                       + "Alternatively can be provided as PV or PVS macros")
+
+        # Parse arguments and ignore unknowns
+        trace_args, unknown = trace_parser.parse_known_args(args)
+        if unknown:
+            logger.warning(f"Not using unknown arguments: {unknown}")
+
+        # Get the file to import from if one is provided. Prioritize args over macro
+        input_file = trace_args.input_file
+        if not input_file and 'INPUT_FILE' in macros:
+            input_file = macros['INPUT_FILE']
+
+        startup_pvs = []
+        if 'PV' in macros:
+            startup_pvs.append(macros['PV'])
+        if 'PVS' in macros:
+            startup_pvs.append(*macros['PVS'])
+        startup_pvs.append(*trace_args)
+
+        # Remove duplicates from startup_pvs
+        startup_pvs = list(dict.fromkeys(startup_pvs))
+
+        return (input_file, startup_pvs)
 
     @staticmethod
     def git_version():

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -164,7 +164,7 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
             input_file = macros['INPUT_FILE']
 
         # Get the list of PVs to show on startup
-        startup_pvs = trace_args.pvs
+        startup_pvs = []
         for key in ("PV", "PVS"):
             if key in macros:
                 val = macros[key]
@@ -172,6 +172,7 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
                     startup_pvs.append(val)
                 elif isinstance(val, list):
                     startup_pvs += val
+        startup_pvs += trace_args.pvs
 
         # Remove duplicates from startup_pvs
         startup_pvs = list(dict.fromkeys(startup_pvs))

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -122,7 +122,7 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
 
         Parameters
         ----------
-        macros : Dict[str, Union[str, List]]
+        macros : Dict[str, str | list]
             Dictionary containing all of the macros passed into PyDM
         args : List[str]
             List of all arguments passed into the application to be parsed
@@ -132,6 +132,10 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         tuple
             A tuple containing the file to import from and the list of PVs to use on startup
         """
+        # Default macros is None
+        if not macros:
+            macros = {}
+
         # Construct an argument parser for args
         trace_parser = argparse.ArgumentParser(description="Trace\nThis is a PyDM application "
                                                + "used to display archived and live pv data.",
@@ -159,12 +163,15 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         if not input_file and 'INPUT_FILE' in macros:
             input_file = macros['INPUT_FILE']
 
-        startup_pvs = []
-        if 'PV' in macros:
-            startup_pvs.append(macros['PV'])
-        if 'PVS' in macros:
-            startup_pvs.append(*macros['PVS'])
-        startup_pvs.append(*trace_args)
+        # Get the list of PVs to show on startup
+        startup_pvs = trace_args.pvs
+        for key in ("PV", "PVS"):
+            if key in macros:
+                val = macros[key]
+                if isinstance(val, str):
+                    startup_pvs.append(val)
+                elif isinstance(val, list):
+                    startup_pvs += val
 
         # Remove duplicates from startup_pvs
         startup_pvs = list(dict.fromkeys(startup_pvs))

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -16,9 +16,11 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
     def __init__(self, parent=None, args=None, macros=None, ui_filename=__file__.replace(".py", ".ui")) -> None:
         super(ArchiveViewer, self).__init__(parent=parent, args=args,
                                             macros=macros, ui_filename=ui_filename)
+        # Set up PyDMApplication
         self.configure_app()
         self.set_footer()
 
+        # Initialize the Mixins
         self.axis_table_init()
         self.traces_table_init()
         self.file_io_init()
@@ -26,9 +28,7 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         self.curve_delegates_init()
         self.axis_delegates_init()
 
-        self.ui.main_spltr.setCollapsible(0, False)
-        self.ui.main_spltr.setStretchFactor(0, 1)
-
+        # Create reference dict for timespan_btns button group
         self.button_spans = {self.ui.half_min_scale_btn: 30,
                              self.ui.min_scale_btn: 60,
                              self.ui.hour_scale_btn: 3600,
@@ -37,14 +37,18 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
                              self.ui.cursor_scale_btn: -1}
         self.ui.timespan_btns.buttonClicked.connect(self.set_plot_timerange)
 
+        # Click "Cursor" button on plot-mouse interaction
         plot_viewbox = self.ui.archiver_plot.plotItem.vb
         plot_viewbox.sigRangeChangedManually.connect(self.ui.cursor_scale_btn.click)
 
+        # Parse macros & arguments, then include them in startup
         input_file, startup_pvs = self.parse_macros_and_args(macros, args)
         if input_file:
             self.import_save_file(input_file)
-        for p in startup_pvs:
-            self.curves_model.add_curve(p)
+        for pv in startup_pvs:
+            if pv in self.curves_model:
+                continue
+            self.curves_model.add_curve(pv)
 
     def menu_items(self) -> dict:
         """Add export & import functionality to File menu"""
@@ -65,6 +69,10 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
 
         # Add style to center checkboxes in table cells
         app.setStyle(CenterCheckStyle())
+
+        # Adjust settings for main_spltr
+        self.ui.main_spltr.setCollapsible(0, False)
+        self.ui.main_spltr.setStretchFactor(0, 1)
 
     def set_footer(self):
         """Set footer information for application. Includes logging, nodename,

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -3,7 +3,7 @@ import argparse
 from typing import Tuple, List, Dict
 from logging import (Handler, LogRecord)
 from subprocess import run
-from qtpy.QtCore import Slot
+from qtpy.QtCore import (Slot, Qt)
 from qtpy.QtWidgets import (QAbstractButton, QApplication, QLabel)
 from pydm import Display
 from config import (logger, datetime_pv)
@@ -48,7 +48,9 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         for pv in startup_pvs:
             if pv in self.curves_model:
                 continue
-            self.curves_model.add_curve(pv)
+            last_row = self.curves_model.rowCount() - 1
+            index = self.curves_model.index(last_row, 0)
+            self.curves_model.setData(index, pv, Qt.EditRole)
 
     def menu_items(self) -> dict:
         """Add export & import functionality to File menu"""

--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -13,13 +13,8 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
     def __init__(self, parent=None, args=None, macros=None, ui_filename=__file__.replace(".py", ".ui")) -> None:
         super(ArchiveViewer, self).__init__(parent=parent, args=args,
                                             macros=macros, ui_filename=ui_filename)
+        self.configure_app()
         self.set_footer()
-
-        app = QApplication.instance()
-        app.setStyle(CenterCheckStyle())
-
-        self.ui.main_spltr.setCollapsible(0, False)
-        self.ui.main_spltr.setStretchFactor(0, 1)
 
         self.axis_table_init()
         self.traces_table_init()
@@ -27,6 +22,9 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
 
         self.curve_delegates_init()
         self.axis_delegates_init()
+
+        self.ui.main_spltr.setCollapsible(0, False)
+        self.ui.main_spltr.setStretchFactor(0, 1)
 
         self.button_spans = {self.ui.half_min_scale_btn: 30,
                              self.ui.min_scale_btn: 60,
@@ -39,13 +37,25 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin):
         plot_viewbox = self.ui.archiver_plot.plotItem.vb
         plot_viewbox.sigRangeChangedManually.connect(self.ui.cursor_scale_btn.click)
 
-        app = QApplication.instance()
-        app.setStyle(CenterCheckStyle())
-
     def file_menu_items(self) -> dict:
-        """Add export & import functionality to File menu; override Display.file_menu_items"""
+        """Add export & import functionality to File menu"""
         return {"save": (self.export_save_file, "Ctrl+S"),
                 "load": (self.import_save_file, "Ctrl+L")}
+
+    def configure_app(self):
+        """UI changes to be made to the PyDMApplication"""
+        app = QApplication.instance()
+
+        # Hide navigation bar by default (can be shown in menu bar)
+        app.main_window.toggle_nav_bar(False)
+        app.main_window.ui.actionShow_Navigation_Bar.setChecked(False)
+
+        # Hide status bar by default (can be shown in menu bar)
+        app.main_window.toggle_status_bar(False)
+        app.main_window.ui.actionShow_Status_Bar.setChecked(False)
+
+        # Add style to center checkboxes in table cells
+        app.setStyle(CenterCheckStyle())
 
     def set_footer(self):
         """Set footer information for application. Includes logging, nodename,

--- a/archive_viewer/mixins/file_io.py
+++ b/archive_viewer/mixins/file_io.py
@@ -36,14 +36,15 @@ class FileIOMixin:
             logger.error(e)
             self.export_save_file()
 
-    def import_save_file(self) -> None:
+    def import_save_file(self, file_name: str | Path = None) -> None:
         """Prompt the user for which config file to import from"""
         # Get the save file from the user
-        file_name, _ = QFileDialog.getOpenFileName(self, "Open Archive Viewer",
-                                                   str(self.io_path),
-                                                   "Python Archive Viewer (*.pyav);;"
-                                                   + "Java Archive Viewer (*.xml);;"
-                                                   + "All Files (*)")
+        if not file_name:
+            file_name, _ = QFileDialog.getOpenFileName(self, "Open Archive Viewer",
+                                                       str(self.io_path),
+                                                       "Python Archive Viewer (*.pyav);;"
+                                                       + "Java Archive Viewer (*.xml);;"
+                                                       + "All Files (*)")
         file_name = Path(file_name)
         if not file_name.is_file():
             logger.warning(f"Attempted import is not a file: {file_name}")

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -227,14 +227,3 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             The requested curve.
         """
         return self._plot.curveAtIndex(index)
-
-    def add_curve(self, channel: str) -> None:
-        """Add a default curve with the given channel in the last row of the model
-
-        Parameters
-        ----------
-        channel : str
-            Channel for the new curve
-        """
-        index = self.index(self.rowCount() - 1, 0)
-        self.setData(index, channel, Qt.EditRole)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -30,6 +30,22 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self._axis_model = axis_model
         self.append()
 
+    def __contains__(self, key: str) -> bool:
+        """Check if the given key is a channel that already exists in the model.
+        Allows for the use of the 'in' keyword.
+
+        Parameters
+        ----------
+        key : str
+            Channel to check existence of
+
+        Returns
+        -------
+        bool
+            If the channel already exists in the model
+        """
+        return key in [curve.address for curve in self._plot._curves]
+
     def get_data(self, column_name: str, curve: ArchivePlotCurveItem) -> Any:
         """Get data from the model based on column name.
 

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -212,6 +212,13 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         """
         return self._plot.curveAtIndex(index)
 
-    def add_curve(self, channel: str):
+    def add_curve(self, channel: str) -> None:
+        """Add a default curve with the given channel in the last row of the model
+
+        Parameters
+        ----------
+        channel : str
+            Channel for the new curve
+        """
         index = self.index(self.rowCount() - 1, 0)
         self.setData(index, channel)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -237,4 +237,4 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             Channel for the new curve
         """
         index = self.index(self.rowCount() - 1, 0)
-        self.setData(index, channel)
+        self.setData(index, channel, Qt.EditRole)

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -211,3 +211,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
             The requested curve.
         """
         return self._plot.curveAtIndex(index)
+
+    def add_curve(self, channel: str):
+        index = self.index(self.rowCount() - 1, 0)
+        self.setData(index, channel)

--- a/launch_archive_viewer.bash
+++ b/launch_archive_viewer.bash
@@ -12,7 +12,24 @@ exit_abnormal(){
     exit 1
 }
 
+MACROS=""
+IMPORT_FILE=""
+
+while [ $# -gt 0 ]
+do
+    case $1 in
+        -m | --macros) MACROS="$2"
+                       shift ;;
+        -i | --import) IMPORT_FILE="$2"
+                       shift ;;
+        -h | --help) exit_abnormal ;;
+        *) exit_abnormal
+    esac
+    shift
+done
+
 pydm --hide-nav-bar --hide-status-bar \
+    -m "MACROS" \
     archive_viewer.py
 
 exit 0

--- a/launch_archive_viewer.bash
+++ b/launch_archive_viewer.bash
@@ -13,23 +13,22 @@ exit_abnormal(){
 }
 
 MACROS=""
-IMPORT_FILE=""
+ARGS=""
 
 while [ $# -gt 0 ]
 do
     case $1 in
         -m | --macros) MACROS="$2"
                        shift ;;
-        -i | --import) IMPORT_FILE="$2"
-                       shift ;;
-        -h | --help) exit_abnormal ;;
-        *) exit_abnormal
+        *) ARGS+="$1 " ;;
     esac
     shift
 done
 
+echo $@
+
 pydm --hide-nav-bar --hide-status-bar \
-    -m "MACROS" \
-    archive_viewer.py
+    -m "$MACROS" \
+    archive_viewer.py "$ARGS"
 
 exit 0


### PR DESCRIPTION
Add functionality for macros and arguments. The application will check both macros and arguments for a file to import from, and for lists of PVs to show on startup.

### Macro names:
  - INPUT_FILE : str
    - File path to import from on startup
  - PV or PVS  : str | list
    - A channel or list of channels to show on startup
### Argument flags:
  - -i, --input_file : str
    - File path to import from on startup
  - -p, --pvs : str | list
    - A channel or list of channels to show on startup

Since we can only specify one input file, the argument is given priority over the macros. However, the list of PVs will concatenate values from both macros and arguments. If a channel is listed in multiple places (macro, argument, and/or imported file) it will only be included once.

E.g.
`pydm -m '{"PVS": ["KLYS:LI22:31:KVAC", "KLYS:LI22:41:KVAC"]}' archive_viewer/archive_viewer.py -p KLYS:LI22:31:KVAC -i test_save_as.pyav`
This will open the Archive Viewer with the contents of `test_save_as.pyav` and curves for "KLYS:LI22:31:KVAC" and "KLYS:LI22:41:KVAC".
"KLYS:LI22:31:KVAC" will only show up as a curve once. 

