### PR TITLE
FIX: Small Bug Fixes for File IO

### DIFF
--- a/archive_viewer/av_file_convert.py
+++ b/archive_viewer/av_file_convert.py
@@ -180,7 +180,7 @@ class ArchiveViewerFileConverter():
             pv_dict = {'name': pv_in['name'],
                        'channel': pv_in['name'],
                        'yAxisName': pv_in['range_axis_name'],
-                       'lineWidth': float(pv_in['draw_width']),
+                       'lineWidth': int(float(pv_in['draw_width'])),
                        'color': color.name(),
                        'thresholdColor': color.name()}
             filtered_dict = self.remove_null_values(pv_dict)

--- a/archive_viewer/mixins/file_io.py
+++ b/archive_viewer/mixins/file_io.py
@@ -194,8 +194,10 @@ class IOTimeParser:
         datetime
             The datetime object with the same date and the new time
         """
-        time = cls.time_re.search(time_str).group()
-        if not time:
+        # Get absolute time from string, return datetime if none
+        try:
+            time = cls.time_re.search(time_str).group()
+        except AttributeError:
             return dt
 
         if time.count(':') == 1:


### PR DESCRIPTION
2 small bug fixes for file IO:

1. In av_file_convert.py : convert_data()
  a. For all curves, lineWidth was being converted to a float, which is partially correct since Java saves these as floats, but then they need to be converted to ints after for BasePlotCurveItem to make use of them
  b. Solution: `float(pv_in['draw_width'])` =>  `int(float(pv_in['draw_width']))`
2. In file_io.py : set_time_on_datetime():
  a. Capture unaccounted for AttributeError when relative date time strings don't include an absolute time:
  E.g. `-3d` vs `-3d 8:00:00`
