### PR TITLE
FIX: Formula Dependency Checker Using DFS

### DIFF
--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -222,7 +222,11 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         # Find row headers using regex
 
         rowName = self._row_names[index.row()]
-        pvdict = self.formulaToPVDict(rowName, formula)
+        try:
+            pvdict = self.formulaToPVDict(rowName, formula)
+        except ValueError as e:
+            logger.error(e)
+            return False
         if pvdict == None:
             return False
         curve = self._plot._curves[index.row()]

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -226,11 +226,19 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
     def recursionCheck(self, target: str, rowHeaders: dict) -> bool:
         """Internal method that uses DFS to confirm there are not cyclical formula dependencies
 
-        We are handling base case in the loop so we won't worry about this rn
-        Presumably we are running this every single time formulaToPVDict is called,
-        So our target being the only one we check for is all that matters
-        ^ As opposed to keeping a list of seen rows and making sure there are no repeats
-        Which by the way wouldn't work anyway, because multiple descendants are allowed to use the same rows"""
+        We are handling base case in the loop
+        We are running this every single time formulaToPVDict is called,
+        so our target is the only fail check
+
+        Parameters
+        --------------
+        target: str
+            The row header that initially called this check. If we find it, there is a cyclical dependency
+
+        rowHeaders: dict()
+            This contains rowHeader -> BasePlotCurveItem so we can find all of our dependencies
+                From this we know which Formula we then have to traverse to confirm we are good
+        """
 
         for rowHeader, curve in rowHeaders.items():
             if rowHeader == target:


### PR DESCRIPTION
Old: Would require formulas to reference rows strictly above them. This is hard to understand from the user perspective, but would make ensuring no recursion very easy.

New: DFS to check dependencies making sure we never reach the original curve again.

To Do: how to handle importing Formulas that are not imported in dependency order? 