### PR TITLE
ENH: Drag and Drop PVs from PV search

### DIFF
--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -1,8 +1,9 @@
 from typing import (Dict, Any)
 from qtpy import sip
-from qtpy.QtCore import (Slot, QPoint, QModelIndex, QObject, Qt)
+from qtpy.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent
+from qtpy.QtCore import (Slot, QPoint, QModelIndex, QObject)
 from qtpy.QtWidgets import (QHeaderView, QMenu, QAction, QTableView, QDialog,
-                            QVBoxLayout, QGridLayout, QLineEdit, QPushButton, QAbstractItemView)
+                            QVBoxLayout, QGridLayout, QLineEdit, QPushButton)
 from pydm.widgets.baseplot import BasePlotCurveItem
 from pydm.widgets.baseplot_curve_editor import PlotStyleColumnDelegate
 from config import logger
@@ -91,20 +92,20 @@ class TracesTableMixin:
         delete_row_del = DeleteRowDelegate(self.ui.traces_tbl)
         self.ui.traces_tbl.setItemDelegateForColumn(delete_col, delete_row_del)
 
-    def dragEnterEvent(self, e):
+    def dragEnterEvent(self, e: QDragEnterEvent) -> None:
         """Handle something (like PV names) being dragged into the table"""
-        e.accept()
+        e.acceptProposedAction()
 
-    def dragMoveEvent(self, e):
+    def dragMoveEvent(self, e: QDragMoveEvent) -> None:
         """Handle something (like PV names) being dragged through the table"""
-        e.accept()
+        e.acceptProposedAction()
 
-    def dropEvent(self, e):
+    def dropEvent(self, e: QDropEvent) -> None:
         """Handle something (like PV names) being dropped into the table"""
         data = e.mimeData().text()
         self.insertPVs(data)
 
-    def insertPVs(self, data: str):
+    def insertPVs(self, data: str) -> None:
         """Parse the incoming PV name data
         One by one, add them to the end of the curves model
         Resize the table to match the longest PV name/label
@@ -167,18 +168,9 @@ class TracesTableMixin:
 
 
 class PVContextMenu(QMenu):
-    # TODO: Change this QMenu so functions that change data stay in table object
-    #   - Move functions to table widget
-    #   - Init parameters: dict("ACTION_NAME": function)
-    #   - Init: Loop through dict values:
-    #       - Create action w/ name
-    #       - action.triggered.connect(function)
-    #       - self.addAction(action)
-
-    # data_changed_signal = Signal(int)
-
-    # TODO: Archived PVs are no longer draggable from the search tool. Find out why
-
+    """Right clicking on the curves table opens 3 options - to open a PV search tool,
+    Open a formula dialogue, or import a csv. Importing a csv seems to have not yet been
+    implemented, but Formulae and PV search are."""
     def __init__(self, parent: QObject = None) -> None:
         super().__init__(parent)
 

--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -31,6 +31,7 @@ class TracesTableMixin:
         del_col = self.curves_model.getColumnIndex("")
         self.hdr.setSectionResizeMode(del_col, QHeaderView.ResizeToContents)
         self.setAcceptDrops(True)
+        self.menu.archive_search.append_PVs_requested.connect(self.insertPVs)
 
     def curve_delegates_init(self) -> None:
         """Set column delegates for the Traces table to display widgets."""
@@ -98,6 +99,9 @@ class TracesTableMixin:
 
     def dropEvent(self, e):
         data = e.mimeData().text()
+        self.insertPVs(data)
+
+    def insertPVs(self, data: str):
         logger.info("Accepting PVs " + data)
         channels = data.split(", ")
         for channel in channels:

--- a/archive_viewer/mixins/traces_table.py
+++ b/archive_viewer/mixins/traces_table.py
@@ -92,16 +92,27 @@ class TracesTableMixin:
         self.ui.traces_tbl.setItemDelegateForColumn(delete_col, delete_row_del)
 
     def dragEnterEvent(self, e):
+        """Handle something (like PV names) being dragged into the table"""
         e.accept()
 
     def dragMoveEvent(self, e):
+        """Handle something (like PV names) being dragged through the table"""
         e.accept()
 
     def dropEvent(self, e):
+        """Handle something (like PV names) being dropped into the table"""
         data = e.mimeData().text()
         self.insertPVs(data)
 
     def insertPVs(self, data: str):
+        """Parse the incoming PV name data
+        One by one, add them to the end of the curves model
+        Resize the table to match the longest PV name/label
+
+        Parameters
+        ---------------
+        data: str
+            The list of pvs in string format i.e. \"<pv1>, <pv2>, <pv3>\" etc."""
         logger.info("Accepting PVs " + data)
         channels = data.split(", ")
         for channel in channels:

--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -173,12 +173,12 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
 
         return next_header
 
-    def curve_at_index(self, index: QModelIndex) -> ArchivePlotCurveItem:
+    def curve_at_index(self, index: int | QModelIndex) -> ArchivePlotCurveItem:
         """Return the curve item at the given index.
 
         Parameters
         ----------
-        index : QModelIndex
+        index : int | QModelIndex
             The table index of the requested curve.
 
         Returns
@@ -186,4 +186,6 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         ArchivePlotCurveItem
             The requested curve.
         """
+        if isinstance(index, QModelIndex):
+            index = index.row()
         return self._plot.curveAtIndex(index)

--- a/archive_viewer/widgets/archive_search.py
+++ b/archive_viewer/widgets/archive_search.py
@@ -154,6 +154,9 @@ class ArchiveSearchWidget(QWidget):
         self.setLayout(self.layout)
 
     def selectedPVs(self) -> str:
+        """Figure out based on which indexes were selected, the list of PVs (by string name)
+        The user was hoping to insert into the table. Concatenate them into string form i.e.
+        <pv1>, <pv2>, <pv3>"""
         indices = self.results_view.selectedIndexes()
         pv_list = ""
         for index in indices:
@@ -174,7 +177,7 @@ class ArchiveSearchWidget(QWidget):
         drag.exec_()
 
     def keyPressEvent(self, e: QKeyEvent) -> None:
-        # Special key press tracker, just so that if enter or return is pressed the formula dialog attempts to submit the formula
+        """Special key press tracker, just so that if enter or return is pressed the formula dialog attempts to submit the formula"""
         if e.key() == Qt.Key_Return or e.key() == Qt.Key_Enter:
             self.request_archiver_info()
         return super().keyPressEvent(e)

--- a/archive_viewer/widgets/archive_search.py
+++ b/archive_viewer/widgets/archive_search.py
@@ -1,5 +1,5 @@
 import logging
-from typing import (List, Optional)
+from typing import (List)
 from qtpy.QtGui import QDrag, QKeyEvent
 from qtpy.QtCore import (QAbstractTableModel, QMimeData, QModelIndex, QObject,
                          Qt, QUrl, QVariant, Signal)
@@ -186,6 +186,7 @@ class ArchiveSearchWidget(QWidget):
         """Send the search request to the archiver appliance based on the search string typed into the text box"""
         search_text = self.search_box.text()
         search_text = search_text.replace("?", ".")
+        search_text = search_text.replace("*", ".")
         url_string = (
             f"http://{self.archive_url_textedit.text()}/"
             f"retrieval/bpl/searchForPVsRegex?regex=.*{search_text}.*"


### PR DESCRIPTION
New TracesTableView object that extends QTableView, handles drag and drop events to be able to take in PV names from PV search. Updates its model to set the curve.

It takes a second to load, unknown fix. Added a logger.info to reassure user that the app is just thinking about it rather than making them feel nothing is happening

Dragging and dropping any number of PVs anywhere on the viewer appends them to the end of the table.

Added an "Add PVs" button that does the exact same thing as dragging and dropping the selected names.

Double clicking will select and input a single PV name into the table.

Better search function - hitting enter or return prompts a search rather than having to manually click a button on screen. Also, using '?' works as a buffer character to help search for channel that include any characters in those slots