### PR TITLE
FIX: Shifted axis "hidden" attribute getter to Archive Viewer side 

### DIFF
--- a/archive_viewer/archive_viewer.py
+++ b/archive_viewer/archive_viewer.py
@@ -27,7 +27,8 @@ class ArchiveViewer(Display, TracesTableMixin, AxisTableMixin, FileIOMixin, Plot
 
         self.curve_delegates_init()
         self.axis_delegates_init()
-        self.timespan = -1        self.axis_table_model.reset_everything.connect(self.resetPlot)
+        self.timespan = -1
+        self.axis_table_model.reset_everything.connect(self.resetPlot)
         # Create reference dict for timespan_btns button group
         self.button_spans = {
             self.ui.half_min_scale_btn: 30,

--- a/archive_viewer/table_models/axis_model.py
+++ b/archive_viewer/table_models/axis_model.py
@@ -46,6 +46,8 @@ class ArchiverAxisModel(BasePlotAxesModel):
         """
         if not index.isValid():
             return QVariant()
+        elif role == Qt.CheckStateRole and self._column_names[index.column()] == "Hidden":
+            return Qt.Unchecked if self.plot._axes[index.row()].isVisible() else Qt.Checked
         elif role == Qt.CheckStateRole and index.column() in self.checkable_col:
             value = super().data(index, Qt.DisplayRole)
             return Qt.Checked if value else Qt.Unchecked


### PR DESCRIPTION
This was a suggestion of Jesse's on the PyDM side, so I made this small change to accommodate what would be missing from PyDM if I made those changes