### PR TITLE
FIX: ComboBox Subclasses EditorDelegate

### DIFF
--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -111,6 +111,21 @@ class EditorDelegate(QStyledItemDelegate):
         """
         return super().setModelData(editor, model, index)
 
+    def updateEditorGeometry(self, editor: QWidget, option: QStyleOptionViewItem, _: QModelIndex) -> None:
+        """Updates the geometry of the given index using the specified option.
+
+        Parameters
+        ----------
+        editor : QWidget
+            The editor which will need to be set. Changes type based on
+            how the subclass is implemented.
+        option : QStyleOptionViewItem
+            The item options used in creating the editor
+        _ : QModelIndex
+            Index for the editor (unused)
+        """
+        editor.setGeometry(option.rect)
+
     @Slot()
     def reset_editors(self) -> None:
         """Slot called when the delegate's model will be reset. Closes all

--- a/archive_viewer/widgets/item_delegates.py
+++ b/archive_viewer/widgets/item_delegates.py
@@ -474,7 +474,7 @@ class DeleteRowDelegate(EditorDelegate):
         model.removeAtIndex(index)
 
 
-class ComboBoxDelegate(QStyledItemDelegate):
+class ComboBoxDelegate(EditorDelegate):
     """ComboBoxDelegate is a QStyledItemDelegate to display a persistent
     QComboBox widget on a QTableView.
 
@@ -486,34 +486,35 @@ class ComboBoxDelegate(QStyledItemDelegate):
     data_source : ArchiverAxisModel, list, dict
         The initial dataset to use when populating the QComboBox.
     """
-    sigTextChange = Signal(int, str)
-
     def __init__(self, parent: QTableView, data_source: Union[QAbstractItemModel, list, dict]) -> None:
         super().__init__(parent)
         if isinstance(data_source, list):
             data_source = {v: v for v in data_source}
         self.data_source = data_source
 
-        self.editor_list = []
-        model = self.parent().model()
-        model.modelAboutToBeReset.connect(self.reset_editors)
-
-    def initStyleOption(self, option: QStyleOptionViewItem, index: QModelIndex):
-        """Initialize a QComboBox for use in the Table View.
+    def createEditor(self, parent: QWidget, option: QStyleOptionViewItem, index: QModelIndex) -> QComboBox:
+        """Editor creator function to be overridden by subclasses.
 
         Parameters
         ----------
+        parent : QWidget
+            The parent widget intended to be used as the parent of the new editor
         option : QStyleOptionViewItem
-            The style option used to render the QComboBox
+            The item options used in creating the editor
         index : QModelIndex
-            The index to display the QComboBox on
+            The index to display the editor on
+
+        Returns
+        -------
+        QComboBox
+            The QComboBox editor for the specified index
         """
         if index.row() >= len(self.editor_list):
-            editor = QComboBox()
+            editor = QComboBox(parent)
+            value = index.data(Qt.DisplayRole)
 
             if isinstance(self.data_source, dict):
                 editor.addItems(self.data_source.keys())
-                value = index.data(Qt.DisplayRole)
                 if str(value) in self.data_source:
                     editor.setCurrentText(str(value))
                 else:
@@ -522,7 +523,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
             elif isinstance(self.data_source, QAbstractItemModel):
                 editor.setModel(self.data_source)
                 editor.setModelColumn(0)
-                value = index.data(Qt.DisplayRole)
                 editor.setCurrentText(str(value))
 
             editor.setFocusPolicy(Qt.StrongFocus)
@@ -531,24 +531,8 @@ class ComboBoxDelegate(QStyledItemDelegate):
             editor.currentIndexChanged.connect(lambda: self.commitData.emit(editor))
 
             self.editor_list.append(editor)
-            self.parent().setIndexWidget(index, editor)
+            return editor
         return super().initStyleOption(option, index)
-
-    def destroyEditor(self, editor: QComboBox, index: QModelIndex) -> None:
-        """Destroy the editor for a defined index.
-
-        Parameters
-        ----------
-        editor : QComboBox
-            The editor to be destroyed
-        index : QModelIndex
-            The index of the editor to be destroyed
-        """
-        if index.row() < len(self.editor_list):
-            self.editor_list[index.row()].deleteLater()
-            del self.editor_list[index.row()]
-            return
-        return super().destroyEditor(editor, index)
 
     def setEditorData(self, editor: QComboBox, index: QModelIndex) -> None:
         """Set the editor's data to match the table model's data.
@@ -562,9 +546,11 @@ class ComboBoxDelegate(QStyledItemDelegate):
             The index of the editor to be changed.
         """
         value = index.data(Qt.DisplayRole)
-        ind = editor.findText(value)
-        if ind >= 0:
-            editor.setCurrentIndex(ind)
+        if isinstance(value, str):
+            value = editor.findText(value)
+
+        if isinstance(value, int):
+            editor.setCurrentIndex(value)
 
     def setModelData(self, editor: QComboBox, model: QAbstractTableModel, index: QModelIndex) -> None:
         """Set the table model's data to match the editor's data.
@@ -582,7 +568,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
         if isinstance(self.data_source, dict):
             data = self.data_source[curr_text]
         elif isinstance(self.data_source, QAbstractItemModel):
-            self.sigTextChange.emit(index.row(), curr_text)
             data = curr_text
         model.setData(index, data, Qt.EditRole)
 
@@ -604,19 +589,6 @@ class ComboBoxDelegate(QStyledItemDelegate):
         if event.type() == QEvent.Wheel and not object.hasFocus():
             return True
         return super().eventFilter(object, event)
-
-    @Slot()
-    def reset_editors(self) -> None:
-        """Slot called when the delegate's model will be reset. Closes all
-        persistent editors in the delegate.
-        """
-        for editor in self.editor_list:
-            editor_pos = editor.pos()
-            index = self.parent().indexAt(editor_pos)
-
-            editor.deleteLater()
-            self.parent().closePersistentEditor(index)
-        self.editor_list = []
 
     @Slot(QPoint)
     def combo_menu_requested(self, pos: QPoint) -> None:


### PR DESCRIPTION
This PR does 2 things:
1. Fixes a bug in EditorDelegate:
  a. When implementing a QStyledItemDelegate, I forgot to reimplement the method `updateEditorGeometry`. Without this function, the editors don't update properly on `dataChanged` signals. This should solve some problems I've been having with the delegates
3. ComboBoxDelegate to subclass EditorDelegate:
  a. All other delegates subclass EditorDelegate already
  b. Avoided setting up ComboBoxDelegate this way because it seemed to cause issues in initial testing, turns out it was just the bug with EditorDelegate that is mentioned above and fixed