### PR TITLE
FIX: autoVisible works with FCIs

### DIFF
--- a/archive_viewer/table_models/curve_model.py
+++ b/archive_viewer/table_models/curve_model.py
@@ -345,6 +345,7 @@ class ArchiverCurveModel(PyDMArchiverTimePlotCurvesModel):
         self._plot._curves[index.row()] = FormulaCurve
         FormulaCurve.formula_invalid_signal.connect(partial(self.invalidFormula, header = rowName))
         # Need to check if Formula is referencing a dead row
+        self.plot.plotItem.unlinkDataFromAxis(curve)
         self.plot.removeItem(curve)
         # Disconnect everything and delete it, create a new Formula with the dictionary of curve
         [ch.disconnect() for ch in curve.channels() if ch]


### PR DESCRIPTION
At some point I removed a line that unlinked an old APCI when replacing it with an FCI, leading to axes thinking they had extra curves attached. When trying to autohide, they wouldn't, thinking they still had the old APCI attached. Now we unlink it so autohide works