### PR TITLE
GUI: enable drag-and-drop for moving curve items between axes

### DIFF
--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -273,6 +273,8 @@ class AxisItem(QtWidgets.QWidget):
             event.acceptProposedAction()
             self.placeholder.setMinimumSize(event.source().size())
             self.placeholder.show()
+            if not self._expanded:
+                self.toggle_expand()
 
     def dragMoveEvent(self, event: QtGui.QDragMoveEvent):
         item = self.childAt(event.position().toPoint())


### PR DESCRIPTION
## Description
Implements drag-and-drop for moving curve items between axes and re-ordering curves within an axis. Indicating the drop location is a little jittery and the placeholder can appear in invalid positions, but the curve resets to its original position in those cases.

Closes [SWAPPS-249](https://jira.slac.stanford.edu/browse/SWAPPS-249)
## Screenshots

https://github.com/user-attachments/assets/20f08c67-a0f0-49a1-bcc3-a8f193f33f96
