### PR TITLE
FIX: Checkbox Slots Accept Enum

### DIFF
--- a/trace/widgets/axis_settings.py
+++ b/trace/widgets/axis_settings.py
@@ -31,13 +31,13 @@ class AxisSettingsModal(QWidget):
 
         log_checkbox = QCheckBox(self)
         log_checkbox.setChecked(self.axis.log_mode)
-        log_checkbox.checkStateChanged.connect(self.set_axis_log_mode)
+        log_checkbox.stateChanged.connect(self.set_axis_log_mode)
         log_mode_row = SettingsRowItem(self, "Log Mode", log_checkbox)
         main_layout.addLayout(log_mode_row)
 
         self.grid_checkbox = QCheckBox(self)
         self.grid_checkbox.setChecked(bool(self.axis.grid))
-        self.grid_checkbox.checkStateChanged.connect(self.show_grid)
+        self.grid_checkbox.stateChanged.connect(self.show_grid)
         y_grid_row = SettingsRowItem(self, "Y Axis Gridline", self.grid_checkbox)
         main_layout.addLayout(y_grid_row)
 
@@ -68,12 +68,16 @@ class AxisSettingsModal(QWidget):
             self.axis.show()
 
     @Slot(int)
-    def set_axis_log_mode(self, checked: int):
-        self.axis.log_mode = bool(checked)
+    @Slot(Qt.CheckState)
+    def set_axis_log_mode(self, state: int | Qt.CheckState):
+        checked = Qt.CheckState(state) == Qt.Checked
+        self.axis.log_mode = checked
 
     @Slot(int)
-    def show_grid(self, visible: int):
-        if not visible:
+    @Slot(Qt.CheckState)
+    def show_grid(self, state: int | Qt.CheckState):
+        checked = Qt.CheckState(state) == Qt.Checked
+        if not checked:
             self.axis.setGrid(False)
         else:
             try:

--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -2,7 +2,7 @@ import re
 
 import qtawesome as qta
 from qtpy import QtGui, QtCore, QtWidgets
-from qtpy.QtCore import QTimer
+from qtpy.QtCore import Qt, Slot, QTimer
 from services.theme_manager import Theme, IconColors, ThemeManager
 
 from pydm.widgets.baseplot import BasePlotAxisItem
@@ -368,7 +368,7 @@ class AxisItem(QtWidgets.QWidget):
         layout.addLayout(self.bottom_settings_layout)
         self.auto_range_checkbox = QtWidgets.QCheckBox("Auto")
         self.auto_range_checkbox.setCheckState(QtCore.Qt.Checked if self.source.auto_range else QtCore.Qt.Unchecked)
-        self.auto_range_checkbox.checkStateChanged.connect(self.set_auto_range)
+        self.auto_range_checkbox.stateChanged.connect(self.set_auto_range)
         self.source.linkedView().sigRangeChangedManually.connect(self.disable_auto_range)
         self.bottom_settings_layout.addWidget(self.auto_range_checkbox)
         self.bottom_settings_layout.addWidget(QtWidgets.QLabel("min, max"))
@@ -387,7 +387,7 @@ class AxisItem(QtWidgets.QWidget):
 
         self.active_toggle = ToggleSwitch("Active")
         self.active_toggle.setCheckState(QtCore.Qt.Checked if self.source.isVisible() else QtCore.Qt.Unchecked)
-        self.active_toggle.checkStateChanged.connect(self.set_active)
+        self.active_toggle.stateChanged.connect(self.set_active)
         self.header_layout.addWidget(self.active_toggle)
 
         self.placeholder = QtWidgets.QWidget(self)
@@ -543,16 +543,19 @@ class AxisItem(QtWidgets.QWidget):
                 self.layout().itemAt(index).widget().show()
         self._expanded = not self._expanded
 
-    def set_active(self, state: QtCore.Qt.CheckState):
-        if state == QtCore.Qt.Unchecked:
-            self.source.hide()
-        else:
-            self.source.show()
+    @Slot(int)
+    @Slot(Qt.CheckState)
+    def set_active(self, state: int | Qt.CheckState):
+        checked = Qt.CheckState(state) == Qt.Checked
+        self.source.setVisible(checked)
         for i in range(1, self.layout().count()):
             self.layout().itemAt(i).widget().active_toggle.setCheckState(state)
 
-    def set_auto_range(self, state: QtCore.Qt.CheckState):
-        self.source.auto_range = state == QtCore.Qt.Checked
+    @Slot(int)
+    @Slot(Qt.CheckState)
+    def set_auto_range(self, state: int | Qt.CheckState):
+        checked = Qt.CheckState(state) == Qt.Checked
+        self.source.auto_range = checked
 
     def disable_auto_range(self):
         self.auto_range_checkbox.setCheckState(QtCore.Qt.Unchecked)
@@ -753,7 +756,7 @@ class CurveItem(QtWidgets.QWidget):
 
         self.active_toggle = ToggleSwitch("Active", color=self.source.color_string)
         self.active_toggle.setCheckState(QtCore.Qt.Checked if self.source.isVisible() else QtCore.Qt.Unchecked)
-        self.active_toggle.checkStateChanged.connect(self.set_active)
+        self.active_toggle.stateChanged.connect(self.set_active)
         self.layout().addWidget(self.active_toggle)
 
         second_layout = QtWidgets.QVBoxLayout()
@@ -878,11 +881,11 @@ class CurveItem(QtWidgets.QWidget):
             parent = parent.parent()
         return parent
 
-    def set_active(self, state: QtCore.Qt.CheckState):
-        if state == QtCore.Qt.Unchecked:
-            self.source.hide()
-        else:
-            self.source.show()
+    @Slot(int)
+    @Slot(Qt.CheckState)
+    def set_active(self, state: int | Qt.CheckState):
+        checked = Qt.CheckState(state) == Qt.Checked
+        self.source.setVisible(checked)
 
     def update_live_icon(self, connected: bool) -> None:
         self.live_connection_status.setVisible(not connected)

--- a/trace/widgets/curve_settings.py
+++ b/trace/widgets/curve_settings.py
@@ -75,10 +75,10 @@ class CurveSettingsModal(QWidget):
         width_row = SettingsRowItem(self, "  Width", width_combo)
         main_layout.addLayout(width_row)
 
-        extention_option = QCheckBox(self)
-        extention_option.checkStateChanged.connect(lambda check: self.set_extension_option(bool(check)))
-        extention_option_row = SettingsRowItem(self, "Line Extention", extention_option)
-        main_layout.addLayout(extention_option_row)
+        extension_option = QCheckBox(self)
+        extension_option.stateChanged.connect(self.set_extension_option)
+        extension_option_row = SettingsRowItem(self, "  Line Extension", extension_option)
+        main_layout.addLayout(extension_option_row)
 
         symbol_title_label = SettingsTitle(self, "Symbol")
         main_layout.addWidget(symbol_title_label)
@@ -156,6 +156,16 @@ class CurveSettingsModal(QWidget):
     def set_curve_width(self, width: int) -> None:
         self.curve.lineWidth = width
 
+    @Slot(int)
+    @Slot(Qt.CheckState)
+    def set_extension_option(self, state: int | Qt.CheckState) -> None:
+        """Set the line extension based on the checkbox state."""
+        enable = Qt.CheckState(state) == Qt.Checked
+
+        self.curve.show_extension_line = enable
+        self.curve.getViewBox().addItem(self.curve._extension_line)
+        self.curve.redrawCurve()
+
     @Slot(object)
     def set_symbol_shape(self, shape: str) -> None:
         self.curve.symbol = shape
@@ -163,10 +173,3 @@ class CurveSettingsModal(QWidget):
     @Slot(object)
     def set_symbol_size(self, size: int) -> None:
         self.curve.symbolSize = size
-
-    @Slot(object)
-    def set_extension_option(self, enable: bool) -> None:
-        """Set the line extension based on the checkbox state."""
-        self.curve.show_extension_line = enable
-        self.curve.getViewBox().addItem(self.curve._extension_line)
-        self.curve.redrawCurve()

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -46,7 +46,7 @@ class PlotSettingsModal(QWidget):
         main_layout.addLayout(plot_title_row)
 
         self.legend_checkbox = QCheckBox(self)
-        self.legend_checkbox.checkStateChanged.connect(lambda check: self.plot.setShowLegend(bool(check)))
+        self.legend_checkbox.stateChanged.connect(self.set_show_legend)
         self.legend_checkbox.setChecked(True)  # legend on by default
         legend_row = SettingsRowItem(self, "Show Legend", self.legend_checkbox)
         main_layout.addLayout(legend_row)
@@ -81,7 +81,7 @@ class PlotSettingsModal(QWidget):
         main_layout.addLayout(end_dt_row)
 
         self.crosshair_checkbox = QCheckBox(self)
-        self.crosshair_checkbox.checkStateChanged.connect(lambda check: self.plot.enableCrosshair(check, 100, 100))
+        self.crosshair_checkbox.stateChanged.connect(self.set_crosshair)
         crosshair_row = SettingsRowItem(self, "Show Crosshair", self.crosshair_checkbox)
         main_layout.addLayout(crosshair_row)
 
@@ -101,12 +101,12 @@ class PlotSettingsModal(QWidget):
         main_layout.addLayout(axis_tick_font_size_row)
 
         self.x_grid_checkbox = QCheckBox(self)
-        self.x_grid_checkbox.checkStateChanged.connect(self.show_x_grid)
+        self.x_grid_checkbox.stateChanged.connect(self.show_x_grid)
         x_grid_row = SettingsRowItem(self, "  X Axis Gridline", self.x_grid_checkbox)
         main_layout.addLayout(x_grid_row)
 
         self.y_grid_checkbox = QCheckBox(self)
-        self.y_grid_checkbox.checkStateChanged.connect(self.show_y_grid)
+        self.y_grid_checkbox.stateChanged.connect(self.show_y_grid)
         y_grid_row = SettingsRowItem(self, "  All Y Axis Gridlines", self.y_grid_checkbox)
         main_layout.addLayout(y_grid_row)
 
@@ -144,6 +144,12 @@ class PlotSettingsModal(QWidget):
         global_pos = self.parent().mapToGlobal(parent_pos)
         self.move(global_pos)
         super().show()
+
+    @Slot(int)
+    @Slot(Qt.CheckState)
+    def set_show_legend(self, state: int | Qt.CheckState) -> None:
+        checked = Qt.CheckState(state) == Qt.Checked
+        self.plot.setShowLegend(checked)
 
     @Slot(int)
     def set_axis_tick_font_size(self, size: int) -> None:
@@ -185,6 +191,12 @@ class PlotSettingsModal(QWidget):
         self.plot.plotItem.setXRange(*proc_range, padding=0)
         self.plot.plotItem.vb.blockSignals(False)
 
+    @Slot(int)
+    @Slot(Qt.CheckState)
+    def set_crosshair(self, state: int | Qt.CheckState) -> None:
+        checked = Qt.CheckState(state) == Qt.Checked
+        self.plot.enableCrosshair(checked, 100, 100)
+
     @Slot(object, object)
     def set_axis_datetimes(self, _: ViewBox = None, time_range: tuple[float, float] = None) -> None:
         """Slot used to update the QDateTimeEdits on the Axis tab. This
@@ -213,14 +225,17 @@ class PlotSettingsModal(QWidget):
             qdt.blockSignals(False)
 
     @Slot(int)
-    def show_x_grid(self, visible: int):
+    @Slot(Qt.CheckState)
+    def show_x_grid(self, state: int | Qt.CheckState) -> None:
         """Slot to show or hide the X-Axis gridlines."""
+        visible = Qt.CheckState(state) == Qt.Checked
         opacity = self.gridline_opacity
-        self.set_plot_gridlines(bool(visible), opacity)
+        self.set_plot_gridlines(visible, opacity)
 
     @Slot(int)
-    def show_y_grid(self, visible: int):
-        visible = bool(visible)
+    @Slot(Qt.CheckState)
+    def show_y_grid(self, state: int | Qt.CheckState) -> None:
+        visible = Qt.CheckState(state) == Qt.Checked
         self.set_all_y_axis_gridlines.emit(visible)
 
     @Slot(int)


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Fix an issue with the slots that Checkboxes are connected to. In PyQt5, `QCheckBox.stateChanged` passed an `int`, but in PySide6 it passes a python enum `CheckState` which can't be treated as an `int`. This PR fixes the slots to take in either an `int` or `CheckState`.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An effort to upgrade from PyQt5 to Pyside6.


<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. 
<!--  This can simply be  a comment in the code or updating a docstring

## Screenshots -->

## Pre-merge checklist

- [x] Code works interactively
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
