### PR TITLE
Set AutoScroll for Any Relative Time

### DIFF
--- a/docs/overview/plot_section.md
+++ b/docs/overview/plot_section.md
@@ -30,7 +30,9 @@ For instance, toggling the 1h button will result in the last hour of data being 
 
 ## Time Span LineEdit
 
-Next to the time span buttons is a LineEdit where the user can enter any timescale as an int or float, with the last character specified as 'm', 'h', 'd', 'w', or 'M' to specify minutes, hours, days, weeks, or months. Entering a timescale here and hitting the return key will result in the specified timescale being displayed on the plot. For example, entering '1h' will display the last hour of data, '2w' will display the last two weeks.
+Next to the time span buttons is a LineEdit where the user can enter any timescale as an int or float, with the last character specified as
+'m', 'h', 'd', 'w', or 'M' to specify minutes, hours, days, weeks, or months. Entering a timescale here and hitting the return key will
+result in the specified timescale being displayed on the plot. For example, entering '1h' will display the last hour of data, '2w' will display the last two weeks.
 
 
 ## Plot Settings

--- a/trace/main.py
+++ b/trace/main.py
@@ -346,17 +346,6 @@ class TraceDisplay(Display):
         to the end of a float timescale to select minutes, hours, days, weeks, or months.
         Timescale multiplier is set accordingly, and if the remaining entry can be
         converted to a float, the timescale is changed accordingly.
-
-        Parameters
-        ----------
-        None
-            Gets time setting from user entered text on GUI
-
-        Returns
-        -------
-        None
-            Calls set_auto_scroll_span with float arg timescale
-
         """
 
         MULTIPLIERS = {"m": 60, "h": 3600, "d": 86400, "w": 604800, "M": 2628300}


### PR DESCRIPTION
## Description
Adds the ability to set any timescale as an int or float, with the last character specified as 'm', 'h', 'd', 'w', or 'M' to specify minutes, hours, days, weeks, or months. For example, entering '1h' will display the last hour of data, '2w' will display the last two weeks.

## Motivation
[FEATURE] - Set AutoScroll for Any Relative Time #172



## Where Has This Been Documented?
Updated overview/plot_section of documentation
