### PR TITLE
FIX: Couldn't Adjust Font Size

### DIFF
--- a/trace/stylesheets/dark_mode.qss
+++ b/trace/stylesheets/dark_mode.qss
@@ -1,7 +1,6 @@
 /* Global Styles */
 QWidget {
     background-color: #1E1E1E;
-    font-size: 10px;
     color: #E0E0E0;
 }
 
@@ -168,7 +167,7 @@ QWidget[collapsible=true] {
 
 QLabel[sectionHeader=true] {
     font-weight: bold;
-    font-size: 11px;
+    font-size: 11pt;
     color: #E0E0E0;
 }
 
@@ -282,7 +281,7 @@ QToolTip {
     color: #FFFFFF;
     border: 1px solid #888888;
     padding: 4px;
-    font-size: 10px;
+    font-size: 10pt;
 }
 
 /* Scrollbars */

--- a/trace/stylesheets/light_mode.qss
+++ b/trace/stylesheets/light_mode.qss
@@ -1,7 +1,6 @@
 /* Global Styles */
 QWidget {
     background-color: #FAFAFA;
-    font-size: 10px;
     color: #202020;
 }
 
@@ -168,7 +167,7 @@ QWidget[collapsible=true] {
 
 QLabel[sectionHeader=true] {
     font-weight: bold;
-    font-size: 11px;
+    font-size: 11pt;
     color: #E0E0E0;
 }
 
@@ -282,7 +281,7 @@ QToolTip {
     color: #FFFFFF;
     border: 1px solid #888888;
     padding: 4px;
-    font-size: 10px;
+    font-size: 10pt;
 }
 
 /* Scrollbars */

--- a/trace/widgets/plot_settings.py
+++ b/trace/widgets/plot_settings.py
@@ -197,10 +197,10 @@ class PlotSettingsModal(QWidget):
         Parameters
         ----------
         size : int
-            The font size in pixels
+            The font size in points
         """
         font = QFont()
-        font.setPixelSize(size)
+        font.setPointSize(size)
 
         all_axes = self.plot.plotItem.getAxes()
         for axis in all_axes:

--- a/trace/widgets/settings_components.py
+++ b/trace/widgets/settings_components.py
@@ -27,13 +27,13 @@ class SettingsTitle(QLabel):
         text : str
             The title text to display
         size : int, optional
-            Custom font size in pixels
+            Custom font size in points
         """
         super().__init__(text=text, parent=parent)
         bold_font = QFont()
         bold_font.setBold(True)
         if size is not None:
-            bold_font.setPixelSize(size)
+            bold_font.setPointSize(size)
         self.setFont(bold_font)
 
 


### PR DESCRIPTION
## Description
An issue with PyDM's font size adjustment options came from our stylesheets defining a `font-size` for all `QWidget`s. My solution is to remove the set `font-size` for all widgets as it seems unnecessary.

A second issue came up with the adjustments whenever a font size was given in the pixel units instead of point units. I changed all fonts to use points instead of pixels.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users couldn't make use of PyDM's font size adjustment options (last worked on in https://github.com/slaclab/pydm/pull/441). 

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
