### PR TITLE
Axis placement bug fix

### DIFF
--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -334,12 +334,12 @@ class ControlPanel(QtWidgets.QWidget):
             last_axis = self.add_empty_axis()
 
         if pv.startswith("f://"):
-            curve = last_axis.add_formula_curve(pv)
+            return last_axis.add_formula_curve(pv)
         else:
             curve = last_axis.add_curve(pv)
-            curve.move_to_axis_from_unit()
+            curve.move_to_axis_from_unit()  # Move to axis based on unit
 
-        return curve
+            return curve
 
     def clear_all(self) -> None:
         """Clear all axes and curves from the plot and control panel."""
@@ -957,6 +957,7 @@ class CurveItem(QtWidgets.QWidget):
         self.setup_layout()
 
     def move_to_axis_from_unit(self):
+        """Automatically move curve to axis based on unit"""
         if not self.is_formula_curve():
             unit = self.source.units
             if unit:


### PR DESCRIPTION
## Description
Removed the axis assignment from CurveItem.init. A new function move_to_axis_from_unit provides the same behavior when desired.

## Motivation
[BUG] - saved file doesn't save axis settings #222
When loading a saved Trace config, the specified axes were effectively being overwritten by the CurveItems setting their axis based on units when initialized. This PR moves that auto-axis assignment to a separate function which is called when curves are added normally (through ControlPanel.add_curve) but not when curves/axes are loaded from a file (ControlPanel.set_curves)

