### PR TITLE
change default line connection to stepMode

### DIFF
--- a/trace/widgets/control_panel.py
+++ b/trace/widgets/control_panel.py
@@ -619,6 +619,7 @@ class AxisItem(QtWidgets.QWidget):
             args.update(channel_args)
 
         plot_curve_item = self.plot.addYChannel(**args)
+        plot_curve_item.stepMode = "right"
 
         return self.make_curve_widget(plot_curve_item)
 


### PR DESCRIPTION
## Description
Makes `stepMode = "right"` the default visual connection type for lines on the plot. It can still be changed to ‘direct’ from the settings menu

## Motivation
[FEATURE] - allow selection of line type "step" from command line. #219
Making `stepMode = "right"` the default seemed to be the most straightforward option, especially since current tools (StripTool, Archive Viewer) use this as default
