### PR TITLE
DOCS: Update Plot Settings modal access location

### DIFF
--- a/docs/plot_config.md
+++ b/docs/plot_config.md
@@ -2,7 +2,7 @@
 
 The Plot Settings modal allows you to customize the appearance and behavior of your plot. These settings are saved with Trace configuration files (`.trc`) and can be shared between users.
 
-Access the Plot Settings by clicking the gear icon (:octicons-gear-16:) in the top-right corner of the plot area.
+Access the Plot Settings by clicking the gear icon (:octicons-gear-16:) in the top-left corner of the plot area.
 
 <figure markdown="span">
   ![Plot Settings Modal](images/plot_settings_modal.png){ width=300 }


### PR DESCRIPTION
## Description
Correct the location of the plot settings button in the docs.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #217 

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://slaclab.github.io/trace/plot_config/

## Pre-merge checklist

- [x] Code works interactively
- [x] Test suite passes on GitHub Actions
